### PR TITLE
[guides] fix broken links

### DIFF
--- a/site/en/guides/build/commissioning.md
+++ b/site/en/guides/build/commissioning.md
@@ -1,7 +1,7 @@
 # Thread Commissioning
 
 <figure class="attempt-right">
-<a href="/guides/images/ot-primer-joiner_2x.png"><img src="/guides/images/ot-primer-joiner.png" srcset="/guides/images/ot-primer-joiner.png 1x, /guides/images/ot-primer-joiner_2x.png 2x" border="0" alt="Commissioner and Joiner" /></a>
+<a href="../../guides/images/ot-primer-joiner_2x.png"><img src="../../guides/images/ot-primer-joiner.png" srcset="../../guides/images/ot-primer-joiner.png 1x, ../../guides/images/ot-primer-joiner_2x.png 2x" border="0" alt="Commissioner and Joiner" /></a>
 </figure>
 
 Commissioning requires one device with the Commissioner role, and one device
@@ -16,7 +16,7 @@ key.
 
 This guide covers basic, on-mesh commissioning without an external Commissioner
 or Border Router. To learn how to use an external Commissioner, see [External
-Thread Commissioning](/guides/border-router/external-commissioning).
+Thread Commissioning](https://openthread.io/guides/border-router/external-commissioning).
 
 For an example of commissioning using virtual devices, see the
 [OpenThread Simulation Codelab](https://openthread.io/codelabs/openthread-simulation/#3).

--- a/site/en/guides/build/features/child-supervision.md
+++ b/site/en/guides/build/features/child-supervision.md
@@ -27,7 +27,7 @@ the parent router enqueues and sends a Child Supervision message to the child
 SED. The Child Supervision message is a MAC frame containing the following
 information:
 
-*   The [RLOC16](/guides/thread-primer/ipv6-addressing#how_a_routing_locator_is_generated)
+*   The [RLOC16](../../../guides/thread-primer/ipv6-addressing.md#how_a_routing_locator_is_generated)
     of the SED as the destination in the MAC header.
 *   An empty payload.
 
@@ -41,7 +41,7 @@ If an SED does not hear from its parent router within the
 [`OPENTHREAD_CONFIG_CHILD_SUPERVISION_CHECK_TIMEOUT`](#check-timeout),
 it assumes that it has lost its connection to the parent router and initiates
 the [MLE
-Attach](/guides/thread-primer/network-discovery#join_an_existing_network)
+Attach](../../../guides/thread-primer/network-discovery.md#join_an_existing_network)
 process to reattach to the parent router.
 
 ## How to enable
@@ -56,7 +56,7 @@ type of end device.
 To enable Child Supervision, define
 `OPENTHREAD_CONFIG_CHILD_SUPERVISION_ENABLE` as `1` in the
 [`/src/core/config/child_supervision.h`](https://github.com/openthread/openthread/tree/main/src/core/config/child_supervision.h)
-file, prior to [building OpenThread](/guides/build):
+file, prior to [building OpenThread](../../../guides/build/index.md):
 
 ```
 #ifndef OPENTHREAD_CONFIG_CHILD_SUPERVISION_ENABLE
@@ -67,7 +67,7 @@ file, prior to [building OpenThread](/guides/build):
 ### By switch
 
 Alternatively, use the `CHILD_SUPERVISION=1` build switch when [building
-OpenThread](/guides/build):
+OpenThread](../../..//guides/build/index.md):
 
 ```
 $ make -f examples/Makefile-{platform} CHILD_SUPERVISION=1
@@ -162,7 +162,7 @@ to customize this feature:
 
 ## API
 
-Use the [Child Supervision API](/reference/group/api-child-supervision) to
+Use the [Child Supervision API](https://openthread.io/reference/group/api-child-supervision) to
 manage the supervision and check timeout intervals directly in your OpenThread
 application.
 

--- a/site/en/guides/build/features/inform-previous-parent-on-reattach.md
+++ b/site/en/guides/build/features/inform-previous-parent-on-reattach.md
@@ -5,7 +5,7 @@ router that they have attached to a new parent router, enable the Inform
 Previous Parent on Reattach feature.
 
 This updates the previous parent's child table quicker than the configured
-[child timeout interval](/reference/group/api-thread-general#otthreadgetchildtimeout) and
+[child timeout interval](https://openthread.io/reference/group/api-thread-general#otthreadgetchildtimeout) and
 prevents it from queueing traffic for an ED that it thinks is asleep, but in
 actuality has a new parent.
 
@@ -14,7 +14,7 @@ actuality has a new parent.
 After an ED attaches to a new parent router, it sends a single unicast IPv6
 message containing the following information to its previous parent router:
 
-*   The [Mesh-Local EID](/guides/thread-primer/ipv6-addressing#mesh-local-eid-ml-eid) of the ED
+*   The [Mesh-Local EID](../../../guides/thread-primer/ipv6-addressing.md#mesh-local-eid-ml-eid) of the ED
     as the source address.
 *   The Mesh-Local EID of the previous parent router as the destination address.
 *   An empty payload.
@@ -28,7 +28,7 @@ This feature is disabled by default.
 
 To enable Inform Previous Parent on Reattach, define
 `OPENTHREAD_CONFIG_MLE_INFORM_PREVIOUS_PARENT_ON_REATTACH` as `1` in the
-[`/src/core/config/mle.h`](https://github.com/openthread/openthread/tree/main/src/core/config/mle.h) file, prior to [building OpenThread](/guides/build):
+[`/src/core/config/mle.h`](https://github.com/openthread/openthread/tree/main/src/core/config/mle.h) file, prior to [building OpenThread](../../../guides/build/index.md):
 
 ```
 #ifndef OPENTHREAD_CONFIG_MLE_INFORM_PREVIOUS_PARENT_ON_REATTACH

--- a/site/en/guides/build/features/jam-detection.md
+++ b/site/en/guides/build/features/jam-detection.md
@@ -77,7 +77,7 @@ This feature is disabled by default.
 To enable Jam Detection, define
 `OPENTHREAD_CONFIG_JAM_DETECTION_ENABLE` as `1` in the
 [`/src/core/config/openthread-core-default-config.h`](https://github.com/openthread/openthread/tree/main/src/core/config/openthread-core-default-config.h)
-file, prior to [building OpenThread](/guides/build):
+file, prior to [building OpenThread](../../../guides/build/index.md):
 
 ```
 #ifndef OPENTHREAD_CONFIG_JAM_DETECTION_ENABLE
@@ -88,7 +88,7 @@ file, prior to [building OpenThread](/guides/build):
 ### By switch
 
 Alternatively, use the `JAM_DETECTION=1` build switch when [building
-OpenThread](/guides/build):
+OpenThread](../../../guides/build/index.md):
 
 ```
 $ make -f examples/Makefile-{platform} JAM_DETECTION=1
@@ -188,7 +188,7 @@ Customize this feature using the following parameters:
 
 ### OpenThread
 
-Use the [Jam Detection API](/reference/group/api-jam-detection) to
+Use the [Jam Detection API](https://openthread.io/reference/group/api-jam-detection) to
 manage the Jam Detection feature directly in your OpenThread application. The
 OpenThread API provides the following functionality:
 

--- a/site/en/guides/build/features/periodic-parent-search.md
+++ b/site/en/guides/build/features/periodic-parent-search.md
@@ -27,7 +27,7 @@ particularly useful when a new router is added to an existing Thread network.
     a parent search is initiated:
     1.  If the parent search discovers a better parent router, the ED dissolves
         its current Child-Parent link and initiates the [MLE
-        Attach](/guides/thread-primer/network-discovery#join_an_existing_network)
+        Attach](../../../guides/thread-primer/network-discovery.md#join_an_existing_network)
         process with the new router.
     1.  If the parent search does not discover a better parent router, the
         existing Child-Parent link remains.
@@ -42,7 +42,7 @@ in RX mode to receive parent responses. Use the backoff interval to limit the
 impact of periodic parent searches on battery-powered devices.
 
 We recommend enabling the [Inform Previous Parent on
-Reattach](/guides/build/features/inform-previous-parent-on-reattach) feature
+Reattach](../../../guides/build/features/inform-previous-parent-on-reattach.md) feature
 in conjunction with this feature.
 
 ## How to enable
@@ -52,7 +52,7 @@ This feature is disabled by default.
 To enable Periodic Parent Search, define
 `OPENTHREAD_CONFIG_PARENT_SEARCH_ENABLE` as `1` in the
 [`/src/core/config/parent_search.h`](https://github.com/openthread/openthread/tree/main//src/core/config/parent_search.h)
-file, prior to [building OpenThread](/guides/build):
+file, prior to [building OpenThread](../../../guides/build/index.md):
 
 ```
 #ifndef OPENTHREAD_CONFIG_PARENT_SEARCH_ENABLE

--- a/site/en/guides/build/index.md
+++ b/site/en/guides/build/index.md
@@ -56,7 +56,7 @@ $ ./script/build -DOT_COMMISSIONER=ON -DOT_JOINER=ON
 ```
 
 Or, to build the nRF52840 platform with the [Jam Detection
-feature](/guides/build/features/jam-detection) enabled in its repo:
+feature](../../guides/build/features/jam-detection.md) enabled in its repo:
 
 ```
 $ ./script/build nrf52840 UART_trans -DOT_JAM_DETECTION=ON
@@ -83,8 +83,8 @@ built but OpenThread library files are still generated in `./build/lib` for use 
 
 Check the example Makefiles for each platform to see which flags each platform
 supports. For more information on FTDs and MTDs, see the
-[Thread Primer](/guides/thread-primer/node-roles-and-types#device_types). For
-more information on SoC and NCP designs, see [Platforms](/platforms/).
+[Thread Primer](../../guides/thread-primer/node-roles-and-types.md#device_types). For
+more information on SoC and NCP designs, see [Platforms](https://openthread.io/platforms/).
 
 The process to flash these binaries varies across example platforms. See the
 READMEs in each platform's
@@ -94,12 +94,12 @@ READMEs in each platform's
 
 OpenThread Daemon (OT Daemon) is an OpenThread POSIX build mode that runs
 OpenThread as a service and is used with the RCP design. For more information on
-how to build and use it, see [OpenThread Daemon](/platforms/co-processor/ot-daemon).
+how to build and use it, see [OpenThread Daemon](https://openthread.io/platforms/co-processor/ot-daemon).
 
 ## Build Support Packages
 
 Build Support Packages (BSPs)  are found in
-[`/third_party`](https://github.com/openthread/openthread/tree/main/third_party). BSPs are additional third-party code used by OpenThread on each respective platform, generally included when [porting OpenThread](/guides/porting/) to a new hardware platform.
+[`/third_party`](https://github.com/openthread/openthread/tree/main/third_party). BSPs are additional third-party code used by OpenThread on each respective platform, generally included when [porting OpenThread](../../guides/porting/index.md) to a new hardware platform.
 
 ### License
 

--- a/site/en/guides/build/logs.md
+++ b/site/en/guides/build/logs.md
@@ -35,7 +35,7 @@ listed in the following file:
 [`/include/openthread/platform/logging.h`](https://github.com/openthread/openthread/tree/main/include/openthread/platform/logging.h)
 
 The list of log levels are also available in the [Platform
-Logging Macros](/reference/group/plat-logging#macros) API reference.
+Logging Macros](https://openthread.io/reference/group/plat-logging#macros) API reference.
 
 The default log level is `OT_LOG_LEVEL_CRIT` which only outputs the most
 critical logs. Change the level to see more logs as desired. To see all
@@ -51,7 +51,7 @@ logging. The region enumeration is defined in the following file:
 [`/include/openthread/platform/logging.h`](https://github.com/openthread/openthread/tree/main/include/openthread/platform/logging.h)
 
 The list of log regions are also available in the [Platform
-Logging Enumerations](/reference/group/plat-logging#otlogregion) API reference.
+Logging Enumerations](https://openthread.io/reference/group/plat-logging#otlogregion) API reference.
 
 Log regions are commonly used as parameters in log functions. All regions are
 enabled by default.
@@ -62,7 +62,7 @@ The default function for logging within OpenThread is `otPlatLog`, defined as
 the compile-time configuration constant of
 `OPENTHREAD_CONFIG_PLAT_LOG_FUNCTION`.
 
-See the [Platform Logging](/reference/group/plat-logging#otplatlog) API
+See the [Platform Logging](https://openthread.io/reference/group/plat-logging#otplatlog) API
 reference for more information on this function.
 
 To use this function directly in the OpenThread example apps, use the `REFERENCE_DEVICE`
@@ -81,7 +81,7 @@ Alternatively, modify the `COMMONCFLAGS` variable in an [example
 ## How to enable logs
 
 Before enabling logs, make sure your environment is configured for building
-OpenThread. See [Build OpenThread](/guides/build) for more information.
+OpenThread. See [Build OpenThread](../../guides/build/index.md) for more information.
 
 ### Enable all logs
 
@@ -247,8 +247,8 @@ Log levels may be changed at run time if dynamic log level control is enabled.
     `OPENTHREAD_CONFIG_ENABLE_DYNAMIC_LOG_LEVEL` to `1`.
 
 1.  Change the log level depending on your implementation:
-    1.  For a [system-on-chip (SoC)](/platforms#single-chip-thread-only-soc),
-        use the [Logging API](/reference/group/api-logging) within your
+    1.  For a [system-on-chip (SoC)](https://openthread.io/platforms#single-chip-thread-only-soc),
+        use the [Logging API](https://openthread.io/reference/group/api-logging) within your
         OpenThread application.
     1.  For an NCP, use `wpanctl` on the command line. See [`wpan-properties.h`](https://github.com/openthread/wpantund/tree/master/src/wpantund/wpan-properties.h) in the `wpantund` repository for all the properties exposed to `wpanctl` and the  [Spinel API](https://github.com/openthread/openthread/blob/da12dca4d9e82cda08aba272567affa188bf8b12/src/ncp/spinel.h#L308) for its log level definitions.
 

--- a/site/en/guides/porting/implement-advanced-features.md
+++ b/site/en/guides/porting/implement-advanced-features.md
@@ -13,10 +13,10 @@ primarily for sleepy end devices (SEDs) which sleep most of the time,
 periodically waking to poll the parent for queued data.
 
 -   **Direct Transmission** — parent sends a data frame directly to the end device
-    <img src="/guides/images/ot-auto-frame-direct.png" srcset="/guides/images/ot-auto-frame-direct.png 1x, /guides/images/ot-auto-frame-direct_2x.png 2x" border="0" alt="Direct Transmission" width="400" />
+    <img src="../../guides/images/ot-auto-frame-direct.png" srcset="../../guides/images/ot-auto-frame-direct.png 1x, ../../guides/images/ot-auto-frame-direct_2x.png 2x" border="0" alt="Direct Transmission" width="400" />
 
 -   **Indirect Transmission** — parent holds data until requested by its intended end device
-    <img src="/guides/images/ot-auto-frame-indirect.png" srcset="/guides/images/ot-auto-frame-indirect.png 1x, /guides/images/ot-auto-frame-indirect_2x.png 2x" border="0" alt="Direct Transmission" width="400" />
+    <img src="../../guides/images/ot-auto-frame-indirect.png" srcset="../../guides/images/ot-auto-frame-indirect.png 1x, ../../guides/images/ot-auto-frame-indirect_2x.png 2x" border="0" alt="Direct Transmission" width="400" />
 
 In the Indirect case, a child end device must first poll the parent to determine
 whether any data is available for it. To do this, the child sends a data

--- a/site/en/guides/porting/implement-platform-abstraction-layer-apis.md
+++ b/site/en/guides/porting/implement-platform-abstraction-layer-apis.md
@@ -4,7 +4,7 @@ OpenThread is OS and platform agnostic, with a narrow Platform Abstraction Layer
 (PAL). This PAL defines:
 
 <figure class="attempt-right">
-<img src="/guides/images/ot-arch-porting.png" srcset="/guides/images/ot-arch-porting.png 1x, /guides/images/ot-arch-porting_2x.png 2x" border="0" alt="Porting Architecture" />
+<img src="../../guides/images/ot-arch-porting.png" srcset="../../guides/images/ot-arch-porting.png 1x, ../../guides/images/ot-arch-porting_2x.png 2x" border="0" alt="Porting Architecture" />
 </figure>
 
 -   Alarm interface for free-running timer with alarm
@@ -198,7 +198,7 @@ implement the initialization of other modules (for example, UART, Radio, Random,
 Misc/Reset) in this source file.
 
 Implementation of this API depends on your use case. If you wish to use the
-generated [CLI and NCP applications](https://openthread.io/guides/build#binaries) for an [example
+generated [CLI and NCP applications](../../guides/build/index.md#binaries) for an [example
 platform](https://github.com/openthread/openthread/tree/main/examples/platforms),
 you must implement this API. Otherwise, any API can be implemented to integrate
 the example platform drivers into your system/RTOS.


### PR DESCRIPTION
A bunch of links were broken on GitHub (but are working on openthread.io after import).  Any links to existing docs on GitHub are now relative with .md filenames.