### PR TITLE
Format Codelab for importing and license updates

### DIFF
--- a/site/en/codelabs/openthread-hardware/index.lab.md
+++ b/site/en/codelabs/openthread-hardware/index.lab.md
@@ -1,31 +1,3 @@
-/*
- *  Copyright (c) 2021, The OpenThread Authors.
- *  All rights reserved.
- *
- *  Redistribution and use in source and binary forms, with or without
- *  modification, are permitted provided that the following conditions are met:
- *  1. Redistributions of source code must retain the above copyright
- *     notice, this list of conditions and the following disclaimer.
- *  2. Redistributions in binary form must reproduce the above copyright
- *     notice, this list of conditions and the following disclaimer in the
- *     documentation and/or other materials provided with the distribution.
- *  3. Neither the name of the copyright holder nor the
- *     names of its contributors may be used to endorse or promote products
- *     derived from this software without specific prior written permission.
- *
- *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- *  POSSIBILITY OF SUCH DAMAGE.
- */
- 
 ---
 id: openthread-hardware
 summary: In this Codelab, you'll program OpenThread on real hardware, create and manage a Thread network, and pass messages between nodes.
@@ -33,13 +5,13 @@ status: [final]
 authors: Jeff Bumgardner
 categories: Nest
 tags: web
-feedback link: https://github.com/openthread/openthread/issues
+feedback link: https://github.com/openthread/ot-docs/issues
 
 ---
 
 # Build a Thread network with nRF52840 boards and OpenThread
 
-[Codelab Feedback](https://github.com/openthread/openthread/issues)
+[Codelab Feedback](https://github.com/openthread/ot-docs/issues)
 
 
 ## Introduction
@@ -48,7 +20,7 @@ feedback link: https://github.com/openthread/openthread/issues
 
 <img src="img/26b7f4f6b3ea0700.png" alt="26b7f4f6b3ea0700.png" width="624.00" />
 
-[OpenThread](https://openthread.io) released by Google is an open-source
+[OpenThread](https://openthread.io/) released by Google is an open-source
 implementation of the  [Thread®](http://threadgroup.org/) networking protocol.
 Google Nest has released OpenThread to make the technology used in Nest products
 broadly available to developers to accelerate the development of products for
@@ -144,7 +116,7 @@ The nRF5x Command Line Tools allow you to flash the OpenThread binaries to the
 nRF52840 boards. Install the appropriate nRF5x-Command-Line-Tools-&lt;OS&gt;
 build on your Linux machine.
 
-<button>[Download nRF5x Command Line Tools](https://www.nordicsemi.com/DocLib/Content/User_Guides/getting_started/latest/UG/common/nordic_tools)</button>
+<button>[Download nRF5x Command Line Tools](https://www.nordicsemi.com/Software-and-tools/Development-Tools/nRF-Command-Line-Tools/Download)</button>
 
 Place the extracted package in the root folder `~/`
 
@@ -225,7 +197,7 @@ $ script/build nrf52840 USB_trans
 > aside positive
 >
 > For more information on building and configuring OpenThread, see
-[Build OpenThread](https://openthread.io/guides/build/).
+[Build OpenThread](../../guides/build/index.md).
 
 Navigate to the directory with the OpenThread RCP binary, and convert it to
 hex format:
@@ -682,7 +654,7 @@ fe80:0:0:0:1cd6:87a9:cb9d:4b1d         # Link-Local Address (LLA)
 > aside positive
 >
 > A single Thread node has multiple IPv6 addresses. For more information, see
-[IPv6 Addressing](https://openthread.io/guides/thread-primer/ipv6-addressing#unicast_address_types).
+[IPv6 Addressing](../../guides/thread-primer/ipv6-addressing.md#unicast-address-types).
 
 The "codelab" network is now visible when scanned from other Thread devices.
 
@@ -1509,20 +1481,20 @@ Building off of this Codelab, try the following exercises:
   addresses
 * Use  [pyspinel](https://github.com/openthread/pyspinel) to control the NCP
 * Convert the NCP into a Border Router using
-  [OpenThread Border Router](https://openthread.io/guides/border-router/build)
+  [OpenThread Border Router](../../guides/border-router/build/index.md)
   and connect your Thread network to the internet
 
 ### Further reading
 
-Check out  [openthread.io](https://openthread.io) and
+Check out [openthread.io](https://openthread.io/) and
 [GitHub](https://github.com/openthread) for a variety of OpenThread resources,
 including:
 
 *  [Supported Platforms](https://openthread.io/platforms/)
     — discover all the platforms that support OpenThread
-*  [Build OpenThread](https://openthread.io/guides/build/)
+*  [Build OpenThread](../../guides/build/index.md)
     — further details on building and configuring OpenThread
-*  [Thread Primer](https://openthread.io/guides/thread-primer/)
+*  [Thread Primer](../../guides/thread-primer/index.md)
     — covers all the Thread concepts featured in this Codelab
 
 Reference:
@@ -1532,4 +1504,31 @@ Reference:
 *  [OpenThread Daemon reference](https://openthread.io/platforms/co-processor/ot-daemon)
 *  [OpenThread UDP API reference](https://openthread.io/reference/group/api-udp)
 *  [GNU Screen quick reference](http://aperiodic.net/screen/quick_reference)
-*  
+
+## License
+
+Copyright (c) 2021, The OpenThread Authors.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+1. Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
+3. Neither the name of the copyright holder nor the
+   names of its contributors may be used to endorse or promote products
+   derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.

--- a/site/en/guides/border-router/beaglebone-black.md
+++ b/site/en/guides/border-router/beaglebone-black.md
@@ -208,3 +208,30 @@ Setup](https://openthread.io/guides/border-router/access-point) for manual
 configuration instructions. The guide is written for Raspberry Pi, but most of
 the configuration steps are applicable to the BeagleBone Debian distribution.
 
+## License
+
+Copyright (c) 2021, The OpenThread Authors.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+1. Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
+3. Neither the name of the copyright holder nor the
+   names of its contributors may be used to endorse or promote products
+   derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.

--- a/site/en/guides/build/commissioning.md
+++ b/site/en/guides/build/commissioning.md
@@ -164,7 +164,7 @@ router
 Done
 ```
 
-### License
+## License
 
 Copyright (c) 2021, The OpenThread Authors.
 All rights reserved.

--- a/site/en/guides/build/features/child-supervision.md
+++ b/site/en/guides/build/features/child-supervision.md
@@ -170,7 +170,7 @@ application.
 
 There are no CLI commands related to this feature.
 
-### License
+## License
 
 Copyright (c) 2021, The OpenThread Authors.
 All rights reserved.

--- a/site/en/guides/build/features/inform-previous-parent-on-reattach.md
+++ b/site/en/guides/build/features/inform-previous-parent-on-reattach.md
@@ -48,7 +48,7 @@ There is no public API for this feature.
 
 There are no CLI commands related to this feature.
 
-### License
+## License
 
 Copyright (c) 2021, The OpenThread Authors.
 All rights reserved.

--- a/site/en/guides/build/features/jam-detection.md
+++ b/site/en/guides/build/features/jam-detection.md
@@ -402,7 +402,7 @@ repository](https://github.com/openthread/wpantund/tree/master/src/wpantund/wpan
 
 > Note: To learn more about managing an NCP using `wpantund` and `wpanctl`, see the [Build a Thread Network Codelab](https://openthread.io/codelabs/openthread-hardware/).
 
-### License
+## License
 
 Copyright (c) 2021, The OpenThread Authors.
 All rights reserved.

--- a/site/en/guides/build/features/periodic-parent-search.md
+++ b/site/en/guides/build/features/periodic-parent-search.md
@@ -156,7 +156,7 @@ There is no public API for this feature.
 
 There are no CLI commands related to this feature.
 
-### License
+## License
 
 Copyright (c) 2021, The OpenThread Authors.
 All rights reserved.

--- a/site/en/guides/build/index.md
+++ b/site/en/guides/build/index.md
@@ -101,7 +101,7 @@ how to build and use it, see [OpenThread Daemon](https://openthread.io/platforms
 Build Support Packages (BSPs)  are found in
 [`/third_party`](https://github.com/openthread/openthread/tree/main/third_party). BSPs are additional third-party code used by OpenThread on each respective platform, generally included when [porting OpenThread](../../guides/porting/index.md) to a new hardware platform.
 
-### License
+## License
 
 Copyright (c) 2021, The OpenThread Authors.
 All rights reserved.

--- a/site/en/guides/build/logs.md
+++ b/site/en/guides/build/logs.md
@@ -254,7 +254,7 @@ Log levels may be changed at run time if dynamic log level control is enabled.
 
             $ wpanctl set OpenThread:LogLevel 5
 
-### License
+## License
 
 Copyright (c) 2021, The OpenThread Authors.
 All rights reserved.

--- a/site/en/guides/thread-primer/index.md
+++ b/site/en/guides/thread-primer/index.md
@@ -35,3 +35,31 @@ It is assumed you have good working knowledge of the following:
 This primer is based on version 1.1.1 of the Thread Specification. It does not
 cover the full specification, which is available at
 [threadgroup.org](http://threadgroup.org/ThreadSpec).
+
+## License
+
+Copyright (c) 2021, The OpenThread Authors.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+1. Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
+3. Neither the name of the copyright holder nor the
+   names of its contributors may be used to endorse or promote products
+   derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.

--- a/site/en/guides/thread-primer/ipv6-addressing.md
+++ b/site/en/guides/thread-primer/ipv6-addressing.md
@@ -274,3 +274,31 @@ What you've learned:
 
 To learn more about Thread's IPv6 addressing, see sections 5.2 and 5.3 of the
 [Thread Specification](http://threadgroup.org/ThreadSpec).
+
+## License
+
+Copyright (c) 2021, The OpenThread Authors.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+1. Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
+3. Neither the name of the copyright holder nor the
+   names of its contributors may be used to endorse or promote products
+   derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.

--- a/site/en/guides/thread-primer/network-discovery.md
+++ b/site/en/guides/thread-primer/network-discovery.md
@@ -290,3 +290,31 @@ What you've learned:
 *   MLE Advertisement messages inform other Thread devices about a device's
     network and link state
 *   The MLE Attach process establishes Child-Parent links
+
+## License
+
+Copyright (c) 2021, The OpenThread Authors.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+1. Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
+3. Neither the name of the copyright holder nor the
+   names of its contributors may be used to endorse or promote products
+   derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.

--- a/site/en/guides/thread-primer/node-roles-and-types.md
+++ b/site/en/guides/thread-primer/node-roles-and-types.md
@@ -150,3 +150,31 @@ What you learned:
 *   Every Thread network partition has a Leader to manage Routers
 *   A Border Router is used to connect Thread and non-Thread networks
 *   A Thread network might be composed of multiple partitions
+
+## License
+
+Copyright (c) 2021, The OpenThread Authors.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+1. Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
+3. Neither the name of the copyright holder nor the
+   names of its contributors may be used to endorse or promote products
+   derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.

--- a/site/en/guides/thread-primer/router-selection.md
+++ b/site/en/guides/thread-primer/router-selection.md
@@ -174,3 +174,31 @@ What you've learned:
 *   Thread devices are upgraded to Routers or downgraded to End Devices to
     maintain the CDS
 *   The MLE Link Request process is used to establish Router-Router links
+
+## License
+
+Copyright (c) 2021, The OpenThread Authors.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+1. Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
+3. Neither the name of the copyright holder nor the
+   names of its contributors may be used to endorse or promote products
+   derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.

--- a/site/zh-cn/guides/thread-primer/index.md
+++ b/site/zh-cn/guides/thread-primer/index.md
@@ -23,3 +23,31 @@ Thread 的主要特性包括：
 * IPv6
 
 本入门教程基于 Thread Specification V1.1.1。Thread Specification 可以在 [threadgroup.org](http://threadgroup.org/ThreadSpec) 中获取。
+
+## License
+
+Copyright (c) 2021, The OpenThread Authors.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+1. Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
+3. Neither the name of the copyright holder nor the
+   names of its contributors may be used to endorse or promote products
+   derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.

--- a/site/zh-cn/guides/thread-primer/ipv6-addressing.md
+++ b/site/zh-cn/guides/thread-primer/ipv6-addressing.md
@@ -229,3 +229,31 @@ Thread 定义了以下 ALOC16 值：
 * 当目的地的 RLOC 未知时，Thread 可以使用任播
 
 要了解有关 Thread 的 IPv6 寻址的更多信息，请参阅 [Thread Specification](http://threadgroup.org/ThreadSpec) 的 5.2 和 5.3 节。
+
+## License
+
+Copyright (c) 2021, The OpenThread Authors.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+1. Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
+3. Neither the name of the copyright holder nor the
+   names of its contributors may be used to endorse or promote products
+   derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.

--- a/site/zh-cn/guides/thread-primer/network-discovery.md
+++ b/site/zh-cn/guides/thread-primer/network-discovery.md
@@ -252,3 +252,31 @@ Child ID Response 是父节点对 Child ID Request 的单播响应，该响应�
 * Thread 使用 MLE 来配置链路并分发有关网络设备的信息
 * MLE Advertisement 消息通知其他 Thread 设备有关设备的网络和链路状态
 * MLE Attach 过程建立了父子链路
+
+## License
+
+Copyright (c) 2021, The OpenThread Authors.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+1. Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
+3. Neither the name of the copyright holder nor the
+   names of its contributors may be used to endorse or promote products
+   derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.

--- a/site/zh-cn/guides/thread-primer/node-roles-and-types.md
+++ b/site/zh-cn/guides/thread-primer/node-roles-and-types.md
@@ -123,3 +123,31 @@ Thread 会尝试将 Router 的数量保持在 16 ～ 23 之间。如果一个 RE
 * 每个 Thread 网络分区都有一个 Leader 来管理 Router
 * Border Router 用于连接 Thread 和其他网络
 * 一个 Thread 网络可能由多个分区组成
+
+## License
+
+Copyright (c) 2021, The OpenThread Authors.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+1. Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
+3. Neither the name of the copyright holder nor the
+   names of its contributors may be used to endorse or promote products
+   derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.

--- a/site/zh-cn/guides/thread-primer/router-selection.md
+++ b/site/zh-cn/guides/thread-primer/router-selection.md
@@ -143,3 +143,31 @@ End Device 也可能希望与相邻的 Router（非父节点）建立接收链�
 * Thread 网络中的 Router 必须形成 CDS
 * Thread 设备将升级成 Router 或降级成 REED 以维护 CDS
 * MLE Link Request 过程用于建立 Router-Router 链路
+
+## License
+
+Copyright (c) 2021, The OpenThread Authors.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+1. Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
+3. Neither the name of the copyright holder nor the
+   names of its contributors may be used to endorse or promote products
+   derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.


### PR DESCRIPTION
Related to https://github.com/openthread/openthread/issues/6526, this updates the Hardware codelab formatting so it can be imported into openthread.io.

Also, added license disclaimers to files that don't have it (except the porting guide, which we'll do after the update is merged), and changed the header level to 2 on those that did have it.