### PR TITLE
Fix placeholder formatting in Thread Primer

### DIFF
--- a/site/en/guides/thread-primer/ipv6-addressing.md
+++ b/site/en/guides/thread-primer/ipv6-addressing.md
@@ -58,8 +58,11 @@ ID = 1 and Child ID = 1):
 
 The RLOC16 is part of the Interface Identifier (IID), which corresponds to the
 last 64 bits of the IPv6 address. Some IIDs can be used to identify some types
-of Thread interfaces. For example, the IID for RLOCs is always of the form
-<code>0000:00ff:fe00:<var>RLOC16</var></code>.
+of Thread interfaces. For example, the IID for RLOCs is always in this form:
+
+```
+0000:00ff:fe00:{RLOC16}
+```
 
 The IID, combined with a Mesh-Local Prefix, results in the RLOC. For example,
 using a Mesh-Local Prefix of `fde5:8dba:82e1:1::/64`, the RLOC for a node where
@@ -242,7 +245,7 @@ devices.
 Anycast is used to route traffic to a Thread interface when the RLOC of a
 destination is not known. An Anycast Locator (ALOC) identifies the location of
 multiple interfaces within a Thread partition. The last 16 bits of an ALOC,
-called the ALOC16, is in the format of <code>0xfc<var>XX</var></code>, which
+called the ALOC16, is in the format of `0xfc{XX}`, which
 represents the type of ALOC.
 
 For example, an ALOC16 between `0xfc01` and `0xfc0f` is reserved for DHCPv6


### PR DESCRIPTION
We had to adjust our openthread.io Copybara import to account for some new code block variations, which ended up conflicting with this one existing example in the Thread Primer.  So I've rewritten them here so that it's no longer an issue.

This is not a problem in the Chinese version of the Thread Primer since it's formatted slightly different (it doesn't have a period directly after the ending code tag), so that is unchanged.