### PR TITLE
Update SiLabs codelab metadata

### DIFF
--- a/site/en/codelabs/silabs-openthread-hardware/index.lab.md
+++ b/site/en/codelabs/silabs-openthread-hardware/index.lab.md
@@ -3,8 +3,8 @@ id: silabs-openthread-hardware
 summary: In this Codelab, you'll program OpenThread on real hardware, create and manage a Thread network, and pass messages between nodes.
 status: [final]
 authors: Mithil Raut
-categories:
-tags:
+categories: Nest
+tags: web
 feedback link: https://github.com/openthread/ot-docs/issues
 
 ---


### PR DESCRIPTION
Some metadata was missing.  Without it, the codelab doesn't appear in the Nest category of the Codelabs index: https://codelabs.developers.google.com/?cat=nest