### PR TITLE
[codelabs] fix type on `thread start` command

### DIFF
--- a/site/en/codelabs/openthread-border-router/index.lab.md
+++ b/site/en/codelabs/openthread-border-router/index.lab.md
@@ -252,7 +252,7 @@ Then, start the Thread interface:
 ```console
 > ifconfig up
 Done
-> Thread start
+> thread start
 Done
 ```
 


### PR DESCRIPTION
Fixes #34 