### PR TITLE
[codelabs] update hw codelabs to always use USB instead of UART

### DIFF
--- a/site/en/codelabs/openthread-border-router-ipv6-multicast/index.lab.md
+++ b/site/en/codelabs/openthread-border-router-ipv6-multicast/index.lab.md
@@ -117,7 +117,7 @@ $ mkdir -p ~/src
 $ cd ~/src
 $ git clone --recurse-submodules --depth 1 https://github.com/openthread/ot-nrf528xx.git
 $ cd ot-nrf528xx/
-$ script/build nrf52840 UART_trans -DOT_MLR=ON -DOT_THREAD_VERSION=1.2
+$ script/build nrf52840 USB_trans -DOT_MLR=ON -DOT_THREAD_VERSION=1.2
 $ arm-none-eabi-objcopy -O ihex build/bin/ot-cli-ftd ot-cli-ftd.hex
 ```
 

--- a/site/en/codelabs/openthread-hardware/index.lab.md
+++ b/site/en/codelabs/openthread-hardware/index.lab.md
@@ -332,7 +332,7 @@ Commissioner and Joiner roles enabled:
 ```console
 $ cd ~/src/ot-nrf528xx
 $ rm -rf build
-$ script/build nrf52840 UART_trans -DOT_JOINER=ON -DOT_COMMISSIONER=ON
+$ script/build nrf52840 USB_trans -DOT_JOINER=ON -DOT_COMMISSIONER=ON
 ```
 
 > aside positive
@@ -375,6 +375,24 @@ $ ./nrfjprog -f nrf52 -s 683704924 --chiperase --program \
 ```
 
 Label the board "Commissioner."
+
+### Connect to native USB
+
+Because the OpenThread FTD build enables use of native USB CDC ACM as a serial
+transport, you must use the **nRF USB** port on the nRF52840 board to
+communicate with the RCP host (Linux machine).
+
+Detach the Micro-USB end of the USB cable from the debug port of the flashed
+nRF52840 board, then reattach it to the Micro-USB **nRF USB** port next to the
+**RESET** button. Set the **nRF power source** switch to **USB**.
+
+<img src="img/46e7b670d2464842.png" alt="46e7b670d2464842.png" width="624.00" />
+
+> aside positive
+>
+> **Note:** When the nRF52840 board is properly connected to a host via the nRF
+USB port, none of the LED indicators light up, even though the board is
+operational.
 
 ### Verify build
 


### PR DESCRIPTION
Fixes #32 