### PR TITLE
Add TOCs for guides and border-router directories

### DIFF
--- a/site/en/guides/_toc.yaml
+++ b/site/en/guides/_toc.yaml
@@ -1,0 +1,38 @@
+toc:
+- title: Get Started
+  path: /guides/
+- heading: Thread Primer
+- title: What is Thread?
+  path: /guides/thread-primer/
+  step_group: thread_primer
+- title: Node Roles and Types
+  path: /guides/thread-primer/node-roles-and-types
+  step_group: thread_primer
+- title: IPv6 Addressing
+  path: /guides/thread-primer/ipv6-addressing
+  step_group: thread_primer
+- title: Network Discovery and Formation
+  path: /guides/thread-primer/network-discovery
+  step_group: thread_primer
+- title: Router Selection
+  path: /guides/thread-primer/router-selection
+  step_group: thread_primer
+- heading: Codelabs
+- title: Simulation with Docker
+  path: /codelabs/openthread-simulation/
+- title: Simulation with Toolchain
+  path: /codelabs/openthread-simulation-posix/
+- title: Build a Thread Network (Nordic)
+  path: /codelabs/openthread-hardware/
+- title: Build a Thread Network (Silicon Labs)
+  path: /codelabs/silabs-openthread-hardware/
+- title: OpenThread APIs
+  path: /codelabs/openthread-apis/
+- title: OpenThread Border Router
+  path: /codelabs/openthread-border-router/
+- title: OpenThread Border Router Thread 1.2 Multicast
+  path: /codelabs/openthread-border-router-ipv6-multicast
+- title: OpenThread Network Simulator
+  path: /codelabs/openthread-network-simulator/
+- title: Testing and Visualization
+  path: /codelabs/openthread-testing-visualization/

--- a/site/en/guides/border-router/_toc.yaml
+++ b/site/en/guides/border-router/_toc.yaml
@@ -1,0 +1,43 @@
+toc:
+- title: Overview
+  path: /guides/border-router/
+- heading: Platforms
+- title: BeagleBone Black
+  path: /guides/border-router/beaglebone-black
+- title: Raspberry Pi
+  path: /guides/border-router/raspberry-pi
+- heading: Setup
+- title: Build and Configuration
+  path: /guides/border-router/build
+  step_group: otbr_setup
+- title: Web GUI
+  path: /guides/border-router/web-gui
+  step_group: otbr_setup
+- title: External Commissioning
+  path: /guides/border-router/external-commissioning
+  step_group: otbr_setup
+- heading: Other
+- title: Tools and Scripts
+  path: /guides/border-router/tools
+- title: Serial Cables
+  path: /guides/border-router/serial-cables
+- heading: Docker Support
+- title: Overview
+  path: /guides/border-router/docker/
+  step_group: otbr_docker
+- title: Run OTBR Docker
+  path: /guides/border-router/docker/run
+  step_group: otbr_docker
+- title: Test Connectivity
+  path: /guides/border-router/docker/test-connectivity
+  step_group: otbr_docker
+- title: Cleanup and Docker Basics
+  path: /guides/border-router/docker/cleanup-and-basics
+  step_group: otbr_docker
+- heading: Codelabs
+- title: OpenThread Border Router
+  status: external
+  path: /codelabs/openthread-border-router/
+- title: OpenThread Border Router Thread 1.2 Multicast
+  status: external
+  path: /codelabs/openthread-border-router-ipv6-multicast


### PR DESCRIPTION
Need to add the _toc.yaml files from openthread.io so they can be updated here as content is added/removed.