### PR TITLE
Adding Google metadata

### DIFF
--- a/site/en/codelabs/openthread-apis/index.lab.md
+++ b/site/en/codelabs/openthread-apis/index.lab.md
@@ -6,7 +6,8 @@ authors: Jeff Bumgardner
 categories: Nest
 tags: web
 feedback link: https://github.com/openthread/ot-docs/issues
-
+project: /_project.yaml
+book: /_book.yaml
 ---
 
 # Developing with OpenThread APIs

--- a/site/en/codelabs/openthread-border-router-ipv6-multicast/index.lab.md
+++ b/site/en/codelabs/openthread-border-router-ipv6-multicast/index.lab.md
@@ -6,7 +6,8 @@ authors: Simon Lin
 categories: Nest
 tags: web
 feedback link: https://github.com/openthread/ot-br-posix/issues
-
+project: /_project.yaml
+book: /_book.yaml
 ---
 
 # Thread Border Router - Thread 1.2 Multicast

--- a/site/en/codelabs/openthread-border-router/index.lab.md
+++ b/site/en/codelabs/openthread-border-router/index.lab.md
@@ -6,7 +6,8 @@ authors: Kangping Dong
 categories: Nest
 tags: web
 feedback link: https://github.com/openthread/ot-br-posix/issues
-
+project: /_project.yaml
+book: /_book.yaml
 ---
 
 # Thread Border Router - Bidirectional IPv6 Connectivity and DNS-Based Service Discovery

--- a/site/en/codelabs/openthread-hardware/index.lab.md
+++ b/site/en/codelabs/openthread-hardware/index.lab.md
@@ -6,7 +6,8 @@ authors: Jeff Bumgardner
 categories: Nest
 tags: web
 feedback link: https://github.com/openthread/ot-docs/issues
-
+project: /_project.yaml
+book: /_book.yaml
 ---
 
 # Build a Thread network with nRF52840 boards and OpenThread

--- a/site/en/codelabs/openthread-network-simulator/index.lab.md
+++ b/site/en/codelabs/openthread-network-simulator/index.lab.md
@@ -6,7 +6,8 @@ authors: Simon Lin, Colin Tan
 categories: Nest
 tags: web
 feedback link: https://github.com/openthread/ot-ns/issues
-
+project: /_project.yaml
+book: /_book.yaml
 ---
 
 # Simulate Thread Networks using OTNS

--- a/site/en/codelabs/openthread-simulation-posix/index.lab.md
+++ b/site/en/codelabs/openthread-simulation-posix/index.lab.md
@@ -6,7 +6,8 @@ authors: Jeff Bumgardner
 categories: Nest
 tags: web
 feedback link:  https://github.com/openthread/ot-docs/issues
-
+project: /_project.yaml
+book: /_book.yaml
 ---
 
 # Simulating a Thread network with OpenThread

--- a/site/en/codelabs/openthread-simulation/index.lab.md
+++ b/site/en/codelabs/openthread-simulation/index.lab.md
@@ -6,7 +6,8 @@ authors: Jeff Bumgardner
 categories: Nest
 tags: io2017,web
 feedback link: https://github.com/openthread/ot-docs/issues
-
+project: /_project.yaml
+book: /_book.yaml
 ---
 
 # Simulating a Thread network using OpenThread in Docker

--- a/site/en/codelabs/openthread-testing-visualization/index.lab.md
+++ b/site/en/codelabs/openthread-testing-visualization/index.lab.md
@@ -6,7 +6,8 @@ authors: Colin Tan
 categories: Nest
 tags: web
 feedback link: https://github.com/openthread/silk/issues
-
+project: /_project.yaml
+book: /_book.yaml
 ---
 
 # Testing a Thread Network with Visualization

--- a/site/en/codelabs/silabs-openthread-hardware/index.lab.md
+++ b/site/en/codelabs/silabs-openthread-hardware/index.lab.md
@@ -6,7 +6,8 @@ authors: Mithil Raut
 categories: Nest
 tags: web
 feedback link: https://github.com/openthread/ot-docs/issues
-
+project: /_project.yaml
+book: /_book.yaml
 ---
 
 # Build a Thread network with Silicon Labs EFR32 boards and OpenThread using Simplicity Studio v5


### PR DESCRIPTION
Adding _project.yaml and _book.yaml metadata entries to each of the codelabs, required by developers.google.com