### PR TITLE
fixed assignment on otTimestamp

### DIFF
--- a/site/en/codelabs/openthread-apis/index.lab.md
+++ b/site/en/codelabs/openthread-apis/index.lab.md
@@ -917,7 +917,9 @@ void setNetworkConfiguration(otInstance *aInstance)
      *     Network Name, Mesh Local Prefix, Extended PAN ID, PAN ID, Delay Timer,
      *     Channel, Channel Mask Page 0, Network Key, PSKc, Security Policy
      */
-    aDataset.mActiveTimestamp                      = 1;
+    aDataset.mActiveTimestamp.mSeconds             = 1;
+    aDataset.mActiveTimestamp.mTicks               = 0;
+    aDataset.mActiveTimestamp.mAuthoritative       = false;
     aDataset.mComponents.mIsActiveTimestampPresent = true;
 
     /* Set Channel to 15 */


### PR DESCRIPTION
The type of otOperationalDataset::mActiveTimestamp has changed from integral type to `struct otTimestamp` in the current version of OpenThread.