### PR TITLE
Update Docker link

### DIFF
--- a/site/en/codelabs/openthread-simulation/index.lab.md
+++ b/site/en/codelabs/openthread-simulation/index.lab.md
@@ -69,7 +69,7 @@ on your system configuration, you may be able to run the `docker` commands using
 
 Install Docker on the OS of your choice.
 
-<button>[Download Docker](https://store.docker.com/search?type=edition&offering=community)</button>
+<button>[Download Docker](https://www.docker.com/get-started/)</button>
 
 ### Pull the Docker image
 


### PR DESCRIPTION
The button 'Download Docker' links to the docker hub instead of the page to download docker.

Although the Docker hub link does point to various installation methods, https://www.docker.com/get-started/ seems a better starting point.