### PR TITLE
Improve NAT64 documentation

### DIFF
--- a/site/en/codelabs/openthread-border-router-nat64/index.lab.md
+++ b/site/en/codelabs/openthread-border-router-nat64/index.lab.md
@@ -113,6 +113,10 @@ The NAT64 prefix will be used by Thread devices when communicating with an IPv4 
 > 
 > **Note:** You may need to ensure IPv4 packet forwarding is enabled in  the system config. The content of `/proc/sys/net/ipv4/conf/default/forwarding` should be `1`.
 
+> aside negative
+> 
+> **Note:** OpenThread does not support the NAT64 well-known prefix `64:ff9b::/96`. Instead, Thread Border Routers dynamically generate their own NAT64 prefixes (as seen above) and publish then as necessary in the Thread Network Data. Thread End Devices must obtain this NAT64 prefix from the Thread Network Data and synthesize their own IPv6 addresses, see [`otNat64SynthesizeIp6Address()`](https://openthread.io/reference/group/api-nat64#otnat64synthesizeip6address). This is automatically done in the CLI, but needs to be specifically implemented in custom applications.
+
 
 ## Setup Thread end device
 Duration: 05:00

--- a/site/en/codelabs/openthread-border-router-nat64/index.lab.md
+++ b/site/en/codelabs/openthread-border-router-nat64/index.lab.md
@@ -115,7 +115,7 @@ The NAT64 prefix will be used by Thread devices when communicating with an IPv4 
 
 > aside negative
 > 
-> **Note:** OpenThread does not support the NAT64 well-known prefix `64:ff9b::/96`. Instead, Thread Border Routers dynamically generate their own NAT64 prefixes (as seen above) and publish then as necessary in the Thread Network Data. Thread End Devices must obtain this NAT64 prefix from the Thread Network Data and synthesize their own IPv6 addresses, see [`otNat64SynthesizeIp6Address()`](https://openthread.io/reference/group/api-nat64#otnat64synthesizeip6address). This is automatically done in the CLI, but needs to be specifically implemented in custom applications.
+> **Note:** OpenThread does not support the NAT64 well-known prefix `64:ff9b::/96`. Instead, Thread Border Routers dynamically generate their own NAT64 prefixes (as seen above) and publish them as necessary in the Thread Network Data. Thread End Devices must obtain this NAT64 prefix from the Thread Network Data and synthesize their own IPv6 addresses, see [`otNat64SynthesizeIp6Address()`](https://openthread.io/reference/group/api-nat64#otnat64synthesizeip6address). This is automatically done in the CLI, but needs to be specifically implemented in custom applications.
 
 
 ## Setup Thread end device

--- a/site/en/codelabs/openthread-border-router-nat64/index.lab.md
+++ b/site/en/codelabs/openthread-border-router-nat64/index.lab.md
@@ -115,7 +115,7 @@ The NAT64 prefix will be used by Thread devices when communicating with an IPv4 
 
 > aside negative
 > 
-> **Note:** OpenThread does not support the NAT64 well-known prefix `64:ff9b::/96`. Instead, Thread Border Routers dynamically generate their own NAT64 prefixes (as seen above) and publish them as necessary in the Thread Network Data. Thread End Devices must obtain this NAT64 prefix from the Thread Network Data and synthesize their own IPv6 addresses, see [`otNat64SynthesizeIp6Address()`](https://openthread.io/reference/group/api-nat64#otnat64synthesizeip6address). This is automatically done in the CLI, but needs to be specifically implemented in custom applications.
+> **Note:** OpenThread does not use the NAT64 well-known prefix `64:ff9b::/96`. Instead, Thread Border Routers publish their dynamically generated NAT64 prefix used by the NAT64 translator in the Thread Network Data (as seen above, the `n` stands for NAT64). Thread End Devices must obtain this NAT64 prefix from the Thread Network Data and synthesize their own IPv6 addresses, see [`otNat64SynthesizeIp6Address()`](https://openthread.io/reference/group/api-nat64#otnat64synthesizeip6address). This is automatically done in the CLI, but needs to be specifically implemented in custom applications.
 
 
 ## Setup Thread end device

--- a/site/en/guides/border-router/external-commissioning/join.md
+++ b/site/en/guides/border-router/external-commissioning/join.md
@@ -39,24 +39,17 @@ fdde:ad11:11de:0:ed8c:1681:24c4:3562
 Test the connectivity between the Joiner device in the Thread network and the
 external internet by pinging a public IPv4 address.
 
-For example, the Well-Known NAT64 prefix of `64:ff9b::/96` and an IPv4 address
-of `8.8.8.8` combine to form an IPv6 address of `64:ff9b::808:808`.
-
-Add an external route for the NAT64 Prefix:
-
-```
-$ sudo ot-ctl route add 64:ff9b::/96 s med
-Done
-$ sudo ot-ctl netdata register
+```console
+> ping 8.8.8.8
+Pinging synthesized IPv6 address: fd4c:9574:3720:2:0:0:808:808
+16 bytes from fd4c:9574:3720:2:0:0:808:808: icmp_seq=15 hlim=119 time=48ms
+1 packets transmitted, 1 packets received. Packet loss = 0.0%. Round-trip min/avg/max = 48/48.0/48 ms.
 Done
 ```
 
-Ping the synthesized IPv6 address `64:ff9b::808:808` from the OpenThread CLI on the Joiner device:
-
-```
-> ping 64:ff9b::808:808
-16 bytes from 64:ff9b:0:0:0:0:808:808: icmp_seq=3 hlim=45 time=72ms
-```
+> aside negative
+> 
+> **Note:**  NAT64 needs to be functional in order to be able to ping IPv4 addresses. For more information on NAT64, see the related colab [Thread Border Router - Provide Internet access via NAT64](https://openthread.io/codelabs/openthread-border-router-nat64).
 
 ## License
 

--- a/site/en/guides/border-router/external-commissioning/join.md
+++ b/site/en/guides/border-router/external-commissioning/join.md
@@ -49,7 +49,7 @@ Done
 
 > aside negative
 > 
-> **Note:**  NAT64 needs to be functional in order to be able to ping IPv4 addresses. For more information on NAT64, see the related colab [Thread Border Router - Provide Internet access via NAT64](https://openthread.io/codelabs/openthread-border-router-nat64).
+> **Note:**  NAT64 needs to be functional in order to be able to ping IPv4 addresses. For more information on NAT64, see the related codelab [Thread Border Router - Provide Internet access via NAT64](https://openthread.io/codelabs/openthread-border-router-nat64).
 
 ## License
 

--- a/site/en/guides/border-router/external-commissioning/join.md
+++ b/site/en/guides/border-router/external-commissioning/join.md
@@ -39,7 +39,7 @@ fdde:ad11:11de:0:ed8c:1681:24c4:3562
 Test the connectivity between the Joiner device in the Thread network and the
 external internet by pinging a public IPv4 address.
 
-```console
+```
 > ping 8.8.8.8
 Pinging synthesized IPv6 address: fd4c:9574:3720:2:0:0:808:808
 16 bytes from fd4c:9574:3720:2:0:0:808:808: icmp_seq=15 hlim=119 time=48ms


### PR DESCRIPTION
As discussed in https://github.com/openthread/ot-br-posix/issues/1858, here are a couple of improvements to the documentation in regards to NAT64.

Namely
- Added a note in the NAT64 colab that the well-known prefix is not supported and custom implementations will need to make use of `otNat64SynthesizeIp6Address()`.
- Removed a mention of the well-known prefix in another guide and added a link to the NAT64 colab.