### PR TITLE
Disclaimer about router terminology on node-roles-and-types.md

### DIFF
--- a/site/en/guides/thread-primer/node-roles-and-types.md
+++ b/site/en/guides/thread-primer/node-roles-and-types.md
@@ -8,13 +8,16 @@
 
 In a Thread network, nodes are split into two forwarding roles:
 
-### Router
+### Router or Thread Mesh Extender
 
 A Router is a node that:
 
 *   forwards packets for network devices
 *   provides secure commissioning services for devices trying to join the network
 *   keeps its transceiver enabled at all times
+
+Routers must be denominated "Thread Mesh Extenders" for all consumer-facing communications,
+but documentation and technical publications might also use the legacy "Router" terminology.
 
 ### End Device
 


### PR DESCRIPTION
Routers are now officially named "Thread Mesh Extenders" on all consumer facing comms. Adding this information here.

Q: should we update *all* documentation to reflect the name change or can we still use "router" in engineering docs and primers?