### PR TITLE
Update Border Router _toc.yaml with Android guide

### DIFF
--- a/site/en/guides/border-router/_toc.yaml
+++ b/site/en/guides/border-router/_toc.yaml
@@ -4,13 +4,14 @@ toc:
 - title: Get Started
   path: /guides/border-router/get-started
 
-- heading: Platforms - Linux
-- title: BeagleBone Black
+- heading: Platforms
+- title: Android
+  path: /android/build-an-android-border-router
+- title: BeagleBone Black (Linux)
   path: /guides/border-router/beaglebone-black
-- title: Raspberry Pi
+- title: Raspberry Pi (Linux)
   path: /guides/border-router/raspberry-pi
-- heading: Platforms - FreeRTOS
-- title: Espressif ESP32 Series
+- title: Espressif ESP32 Series (FreeRTOS)
   path: /guides/border-router/espressif-esp32
 
 - heading: Setup


### PR DESCRIPTION
When we imported the Android Border Router guide from AOSP to openthread.io, I manually changed the border router _toc.yaml there so we could publish it.  Since the source of that file is here on ot-docs, need to update this too so it doesn't get overwritten on a future Copybara run.