### PR TITLE
[ot-docs] replace a 404 file: Change 404 file `openthread/examples/README.md` to `openthread/etc/cmake/options.cmake`

### DIFF
--- a/site/en/guides/build/index.md
+++ b/site/en/guides/build/index.md
@@ -42,7 +42,7 @@ locations:
 Type | Location
 ---- | ----
 Compile-time constants | Listed in all the header files in [`/src/core/config`](https://github.com/openthread/openthread/tree/main/src/core/config)
-cmake build options | Listed in [`openthread/examples/README.md`](https://github.com/openthread/openthread/blob/main/examples/README.md)
+cmake build options | Listed in [`/etc/cmake/options.cmake`](https://github.com/openthread/openthread/tree/main/etc/cmake/options.cmake)
 
 > Note: Each platform repository specifies some, but not all, of the constants and flags that the platform supports. Modify the platform's `openthread-core-{platform}-config.h` file to enable or disable compile-time constants prior to building.
 

--- a/site/en/guides/build/index.md
+++ b/site/en/guides/build/index.md
@@ -42,7 +42,7 @@ locations:
 Type | Location
 ---- | ----
 Compile-time constants | Listed in all the header files in [`/src/core/config`](https://github.com/openthread/openthread/tree/main/src/core/config)
-cmake build options | Listed in [`/etc/cmake/options.cmake`](https://github.com/openthread/openthread/tree/main/etc/cmake/options.cmake)
+cmake build options | Listed in [`/etc/cmake/options.cmake`](https://github.com/openthread/openthread/blob/main/etc/cmake/options.cmake)
 
 > Note: Each platform repository specifies some, but not all, of the constants and flags that the platform supports. Modify the platform's `openthread-core-{platform}-config.h` file to enable or disable compile-time constants prior to building.
 


### PR DESCRIPTION
openthread/examples/README.md was removed when 2023, this docs would lead other to a 404 file. So it needs to be changed as the newest cmake file.

[openthread/examples/README.md](https://github.com/openthread/openthread/blob/main/examples/README.md):

<img width="1642" height="828" alt="image" src="https://github.com/user-attachments/assets/340ba327-9aee-4a54-ad9d-752d931004be" />

https://github.com/openthread/openthread/blob/main/etc/cmake/options.cmake:

<img width="2129" height="1125" alt="image" src="https://github.com/user-attachments/assets/ec0a4e84-13e4-41a1-b4ca-eaa9cbfc85eb" />
