### PR TITLE
[primer] rename Router/REED to Mesh Extender/Extender-Capable Device

### DIFF
--- a/site/en/guides/thread-primer/ipv6-addressing.md
+++ b/site/en/guides/thread-primer/ipv6-addressing.md
@@ -34,20 +34,22 @@ location in the network topology.
 
 ### How a Routing Locator is generated
 
-All devices are assigned a Router ID and a Child ID. Each Router maintains a
-table of all their Children, the combination of which uniquely identifies a
-device within the topology.  For example, consider the highlighted nodes in the
-following topology, where the number in a Router (pentagon) is the Router ID,
-and the number in an End Device (circle) is the Child ID:
+All devices are assigned a Router ID and a Child ID. Each Parent
+maintains a table of all its Children, the combination of which
+uniquely identifies a device within the topology.  For example,
+consider the highlighted nodes in the following topology, where the
+number in a Mesh Extender (pentagon) is the Router ID, and the number
+in an End Device (circle) is the Child ID:
 
 <figure>
 <a href="../images/ot-primer-rloc-topology_2x.png"><img src="../images/ot-primer-rloc-topology.png" srcset="../images/ot-primer-rloc-topology.png 1x, ../images/ot-primer-rloc-topology_2x.png 2x" border="0" width="600" alt="OT RLOC Topology" /></a>
 </figure>
 
-Each Child's Router ID corresponds to their Parent (Router). Because a Router is
-not a Child, the Child ID for a Router is always 0. Together, these values are
-unique for each device in the Thread network, and are used to create the RLOC16,
-which represents the last 16 bits of the RLOC.
+Each Child's Router ID corresponds to its Parent (Mesh
+Extender). Because a Mesh Extender is not a Child, the Child ID for a
+Mesh Extender is always 0. Together, these values are unique for each
+device in the Thread network, and are used to create the RLOC16, which
+represents the last 16 bits of the RLOC.
 
 For example, here's how the RLOC16 is calculated for the upper-left node (Router
 ID = 1 and Child ID = 1):
@@ -81,9 +83,10 @@ This same logic can be used to determine the RLOC for all highlighted nodes in t
 However, because the RLOC is based on the location of the node in the topology,
 the RLOC of a node can change as the topology changes.
 
-For example, perhaps node `0x400` is removed from the Thread network. Nodes
-`0x401` and `0x402` establish new links to different Routers, and as a result
-they are each assigned a new RLOC16 and RLOC:
+For example, perhaps node `0x400` is removed from the Thread
+network. Nodes `0x401` and `0x402` establish new links to different
+Mesh Extenders, and as a result they are each assigned a new RLOC16
+and RLOC:
 
 <figure>
 <a href="../images/ot-primer-rloc-topology-change_2x.png"><img src="../images/ot-primer-rloc-topology-change.png" srcset="../images/ot-primer-rloc-topology-change.png 1x, ../images/ot-primer-rloc-topology-change_2x.png 2x" border="0" width="600" alt="OT Topology after Change" /></a>
@@ -272,7 +275,7 @@ What you've learned:
 *   A Thread device has multiple unicast IPv6 addresses
     *   An RLOC represents a device's location in the Thread network
     *   An ML-EID is unique to a Thread device within a partition and should be used by applications
-*   Thread uses multicast to forward data to groups of nodes and routers
+*   Thread uses multicast to forward data to groups of nodes
 *   Thread uses anycast when the RLOC of a destination is unknown
 
 To learn more about Thread's IPv6 addressing, see sections 5.2 and 5.3 of the
@@ -319,12 +322,12 @@ To learn more about Thread's IPv6 addressing, see sections 5.2 and 5.3 of the
       <div>Incorrect.</div>
     </div>
     <div>
-      <div>The device is a REED.</div>
+      <div>The device is an Extender-Capable Device.</div>
       <div>Close, but incorrect.</div>
     </div>
     <div correct>
-      <div>The device is a Router.</div>
-      <div>Correct. A Router always has a Child ID of 0.</div>
+      <div>The device is a Mesh Extender.</div>
+      <div>Correct. A Mesh Extender always has a Child ID of 0.</div>
     </div>
   </devsite-multiple-choice>
 </div>
@@ -339,10 +342,10 @@ To learn more about Thread's IPv6 addressing, see sections 5.2 and 5.3 of the
         network.</div>
     </div>
     <div correct>
-      <div>A router dropped off the network.</div>
-      <div>Correct. When a router drops off a network, the network
+      <div>A Mesh Extender dropped off the network.</div>
+      <div>Correct. When a Mesh Extender drops off a network, the network
         topology changes, which may result in the device promoting itself to a
-        router and obtaining a new RLOC.</div>
+        Mesh Extender and obtaining a new RLOC.</div>
     </div>
     <div>
       <div>The camera entered sleep mode, which changed the network topology.
@@ -381,7 +384,7 @@ To learn more about Thread's IPv6 addressing, see sections 5.2 and 5.3 of the
 <div>
   <devsite-multiple-choice>
     <div>What type of addressing and routing does Thread use to forward data to
-    groups of nodes and routers?</div>
+    groups of nodes?</div>
     <div>
       <div>unicast</div>
       <div>Incorrect.</div>

--- a/site/en/guides/thread-primer/network-discovery.md
+++ b/site/en/guides/thread-primer/network-discovery.md
@@ -24,9 +24,8 @@ When creating a new Thread network, or searching for an existing one to join, a
 Thread device performs an active scan for 802.15.4 networks within radio range:
 
 1.  The device broadcasts an 802.15.4 Beacon Request on a specific Channel.
-1.  In return, any Routers or Router Eligible End Devices (REEDs) in range
-    broadcast a Beacon that contains their Thread network PAN ID, XPAN ID, and
-    Network Name.
+1.  In return, any Extender-Capable Devices (ECDs) in range broadcast a Beacon that contains
+    their Thread network PAN ID, XPAN ID, and Network Name.
 1.  The device repeats the previous two steps for each Channel.
 
 Once a Thread device has discovered all networks in range, it can either attach
@@ -62,11 +61,12 @@ device has already been commissioned.
 
 ## Create a new network
 
-If the device elects to create a new network, it selects the least busy Channel
-and a PAN ID not in use by other networks, then becomes a Router and elects
-itself the Leader. This device sends MLE Advertisement messages to other
-802.15.4 devices to inform them of its link state, and responds to Beacon
-Requests by other Thread devices performing an active scan.
+If the device elects to create a new network, it selects the least
+busy Channel and a PAN ID not in use by other networks, then becomes a
+Mesh Extender and elects itself the Leader. This device sends MLE
+Advertisement messages to other 802.15.4 devices to inform them of its
+link state, and responds to Beacon Requests by other Thread devices
+performing an active scan.
 
 ## Join an existing network
 
@@ -75,13 +75,13 @@ ID, XPAN ID, and Network Name to match that of the target network via Thread
 Commissioning, then goes through the MLE Attach process to attach as a Child
 (End Device). This process is used for Child-Parent links.
 
-Key Point: Every device, router-capable or not, initially attaches to a Thread
+Key Point: Every device, ECD or not, initially attaches to a Thread
 network as a Child (End Device).
 
 1.  The Child sends a multicast [Parent Request](#1_parent_request) to all
-    neighboring Routers and REEDs in the target network.
-1.  All neighboring Routers and REEDs (if the Parent Request Scan Mask includes
-    REEDs) send [Parent Responses](#2_parent_response) with information about
+    neighboring Extender-Capable Devices in the target network.
+1.  All neighboring Mesh Extenders (and standby ECDs, if the Parent Request Scan Mask includes
+    standby ECDs) send [Parent Responses](#2_parent_response) with information about
     themselves.
 1.  The Child chooses a Parent device and sends a [Child ID
     Request](#3_child_id_request) to it.
@@ -91,8 +91,7 @@ network as a Child (End Device).
 ### 1. Parent Request
 
 A Parent Request is a multicast request from the attaching device that is used
-to discover neighboring Routers and Router Eligible End Devices (REEDs) in the
-target network.
+to discover neighboring Extender-Capable Devices in the target network.
 
 <figure>
 <a href="../images/ot-primer-network-mle-attach-01.png"><img src="../images/ot-primer-network-mle-attach-01.png" width="350" border="0" alt="OT MLE Attach Parent Request" /></a>
@@ -113,15 +112,16 @@ target network.
     </tr>
     <tr>
       <td width="25%"><b>Scan Mask</b></td>
-      <td>Limits the request to only Routers or to both Routers and REEDs</td>
+      <td>Limits the request to only Mesh Extenders or to all Extender-Capable Devices</td>
     </tr>
   </tbody>
 </table>
 
 ### 2. Parent Response
 
-A Parent Response is a unicast response to a Parent Request that provides
-information about a Router or REED to the attaching device.
+A Parent Response is a unicast response to a Parent Request that
+provides information about an Extender-Capable Device to the attaching
+device.
 
 <figure>
 <a href="../images/ot-primer-network-mle-attach-02.png"><img src="../images/ot-primer-network-mle-attach-02.png" width="350" border="0" alt="OT MLE Attach Parent Response" /></a>
@@ -143,31 +143,31 @@ information about a Router or REED to the attaching device.
     <tr>
       <td width="25%"><b>Link Frame
         Counter</b></td>
-      <td>802.15.4 Frame Counter on the Router/REED</td>
+      <td>802.15.4 Frame Counter on the Extender-Capable Device</td>
     </tr>
     <tr>
       <td width="25%"><b>MLE Frame
         Counter</b></td>
-      <td>MLE Frame Counter on the Router/REED</td>
+      <td>MLE Frame Counter on the Extender-Capable Device</td>
     </tr>
     <tr>
       <td width="25%"><b>Source
         Address</b></td>
-      <td>RLOC16 of the Router/REED</td>
+      <td>RLOC16 of the Extender-Capable Device</td>
     </tr>
     <tr>
       <td width="25%"><b>Link
         Margin</b></td>
-      <td>Receive signal quality of the Router/REED</td>
+      <td>Receive signal quality of the Extender-Capable Device</td>
     </tr>
     <tr>
       <td width="25%"><b>Connectivity</b></td>
-      <td>Describes the Router/REED’s level of connectivity</td>
+      <td>Describes the Extender-Capable Device's level of connectivity</td>
     </tr>
     <tr>
       <td width="25%"><b>Leader
         Data</b></td>
-      <td>Information about the Router/REED’s Leader</td>
+      <td>Information about the Extender-Capable Device's Leader</td>
     </tr>
     <tr>
       <td width="25%"><b>Challenge</b></td>
@@ -179,11 +179,11 @@ information about a Router or REED to the attaching device.
 
 ### 3. Child ID Request
 
-A Child ID Request is a unicast request from the attaching device (Child) that
-is sent to the Router or REED (Parent) for the purpose of establishing a
-Child-Parent link. If the request is sent to a REED, it [upgrades itself to a
-Router](router-selection.md) before
-accepting the request.
+A Child ID Request is a unicast request from the attaching device
+(Child) that is sent to the Extender-Capable Device (Parent) for the
+purpose of establishing a Child-Parent link. If the request is sent to
+a standby Extender-Capable Device, it [upgrades itself to a Mesh
+Extender](router-selection.md) before accepting the request.
 
 <figure>
 <a href="../images/ot-primer-network-mle-attach-03.png"><img src="../images/ot-primer-network-mle-attach-03.png" width="350" border="0" alt="OT MLE Attach Child ID Request" /></a>
@@ -242,8 +242,7 @@ Child to confirm that a Child-Parent link has been established.
       <th colspan=2>Child ID Response Message Contents</th>
     </tr>
     <tr>
-      <td width="25%"><b>Source
-        Address</b></td>
+      <td width="25%"><b>Source Address</b></td>
       <td>Parent's RLOC16</td>
     </tr>
     <tr>
@@ -251,20 +250,17 @@ Child to confirm that a Child-Parent link has been established.
       <td>Child's RLOC16</td>
     </tr>
     <tr>
-      <td width="25%"><b>Leader
-        Data</b></td>
+      <td width="25%"><b>Leader Data</b></td>
       <td>Information about the Parent’s Leader (RLOC, Partition ID, Partition
         weight)</td>
     </tr>
     <tr>
-      <td width="25%"><b>Network
-        Data</b></td>
+      <td width="25%"><b>Network Data</b></td>
       <td>Information about the Thread network (on-mesh prefixes, address
         autoconfiguration, more-specific routes)</td>
     </tr>
     <tr>
-      <td width="25%"><b>Route
-        (REED only)</b></td>
+      <td width="25%"><b>Route (standby ECDs only)</b></td>
       <td>Route propagation</td>
     </tr>
     <tr>
@@ -272,8 +268,7 @@ Child to confirm that a Child-Parent link has been established.
       <td>Inactivity duration before the Parent removes the Child</td>
     </tr>
     <tr>
-      <td width="25%"><b>Address
-        Registration (MEDs and SEDs only)</b></td>
+      <td width="25%"><b>Address Registration (MEDs and SEDs only)</b></td>
       <td>Confirm registered addresses</td>
     </tr>
   </tbody>
@@ -323,19 +318,18 @@ What you've learned:
   <devsite-multiple-choice>
     <div>What is a Parent Request used for?</div>
     <div correct>
-      <div>To discover neighboring Routers and Router Eligible End Devices
-      (REEDs) in the target network.</div>
+      <div>To discover neighboring Extender-Capable Devices in the target network.</div>
       <div>Correct. A Parent Request is issued by a device seeking to attach to
       a network.</div>
       </div>
     <div>
-      <div>To announce that a Router is becoming a parent.</div>
-      <div>Incorrect. A Router does not initiate a Parent-Child relationship
-      with another network device. Instead, a network device selects a Router
-      to become its Child.</div>
+      <div>To announce that an Extender-Capable Device is becoming a parent.</div>
+      <div>Incorrect. A Mesh Extender does not initiate a Parent-Child relationship
+      with another network device. Instead, a network device selects an Extender-Capable Device
+      to become its Parent.</div>    
     </div>
     <div>
-      <div>To request that a Router Eligible End Device be promoted to a Router.
+      <div>To request that an Extender-Capable Device be promoted to a Mesh Extender.
       </div>
       <div>Incorrect.</div>
     </div>
@@ -378,7 +372,7 @@ What you've learned:
       <div>Incorrect.</div>
     </div>
     <div>
-      <div>REED (Router-Eligible End Device) </div>
+      <div>Mesh Extender</div>
       <div>Incorrect.</div>
     </div>
   </devsite-multiple-choice>

--- a/site/en/guides/thread-primer/node-roles-and-types.md
+++ b/site/en/guides/thread-primer/node-roles-and-types.md
@@ -8,9 +8,9 @@
 
 In a Thread network, nodes are split into two forwarding roles:
 
-### Router
+### Mesh Extender
 
-A Router is a node that:
+A Mesh Extender is a node that:
 
 *   forwards packets for network devices
 *   provides secure commissioning services for devices trying to join the network
@@ -20,13 +20,14 @@ A Router is a node that:
 
 An End Device (ED) is a node that:
 
-*   communicates primarily with a single Router
+*   communicates primarily with a single Mesh Extender
 *   does not forward packets for other network devices
 *   can disable its transceiver to reduce power
 
-Key Point: The relationship between Router and End Device is a Parent-Child
-relationship. An End Device attaches to exactly one Router. The Router is always
-the Parent, the End Device the Child.
+Key Point: The relationship between a Mesh Extender and an End Device
+is a Parent-Child relationship. An End Device attaches to exactly one
+Mesh Extender. The Mesh Extender is always the Parent, the End Device
+the Child.
 
 ## Device types
 
@@ -40,13 +41,16 @@ Furthermore, nodes comprise a number of types.
 
 A Full Thread Device (FTD) always has its radio on, subscribes to the
 all-routers multicast address, and maintains IPv6 address mappings. There are
-three types of FTDs:
+two types of FTDs:
 
-*   Router
-*   Router Eligible End Device (REED) — can be promoted to a Router
-*   Full End Device (FED) — cannot be promoted to a Router
+*   Extender-Capable Device (ECD)
+*   Full End Device (FED)
 
-An FTD can operate as a Router (Parent) or an End Device (Child).
+An Extender-Capable Device can be in either the Mesh Extender or
+standby ECD role. In the standby role, it's always an End Device
+(Child).
+
+A FED is always an End Device (Child).
 
 ### Minimal Thread Device
 
@@ -63,18 +67,19 @@ An MTD can only operate as an End Device (Child).
 
 ### Upgrading and downgrading
 
-When a REED is the only node in reach of a new End Device wishing to join the
-Thread network, it can upgrade itself and operate as a Router:
+When a standby ECD is the only node in reach of a new Thread device
+wishing to join the Thread network, it can upgrade itself and operate
+as a Mesh Extender:
 
 <figure>
-<a href="../images/ot-primer-router-upgrade_2x.png"><img src="../images/ot-primer-router-upgrade.png" srcset="../images/ot-primer-router-upgrade.png 1x, ../images/ot-primer-router-upgrade_2x.png 2x" border="0" width="400" alt="OT End Device to Router" /></a>
+<a href="../images/ot-primer-router-upgrade_2x.png"><img src="../images/ot-primer-router-upgrade.png" srcset="../images/ot-primer-router-upgrade.png 1x, ../images/ot-primer-router-upgrade_2x.png 2x" border="0" width="400" alt="OT End Device to Mesh Extender" /></a>
 </figure>
 
-Conversely, when a Router has no children, it can downgrade itself and operate
-as an End Device:
+Conversely, when a Mesh Extender has no children, it can downgrade
+itself and operate as a standby ECD:
 
 <figure>
-<a href="../images/ot-primer-router-downgrade_2x.png"><img src="../images/ot-primer-router-downgrade.png" srcset="../images/ot-primer-router-downgrade.png 1x, ../images/ot-primer-router-downgrade_2x.png 2x" border="0" width="400" alt="OT Router to End Device" /></a>
+<a href="../images/ot-primer-router-downgrade_2x.png"><img src="../images/ot-primer-router-downgrade.png" srcset="../images/ot-primer-router-downgrade.png 1x, ../images/ot-primer-router-downgrade_2x.png 2x" border="0" width="400" alt="OT Mesh Extender to End Device" /></a>
 </figure>
 
 ## Other roles and types
@@ -85,9 +90,10 @@ as an End Device:
 <a href="../images/ot-primer-leader_2x.png"><img src="../images/ot-primer-leader.png" srcset="../images/ot-primer-leader.png 1x, ../images/ot-primer-leader_2x.png 2x" border="0" alt="OT Leader and Border Router" /></a>
 </figure>
 
-The Thread Leader is a Router that is responsible for managing the set of
-Routers in a Thread network. It is dynamically self-elected for fault tolerance,
-and aggregates and distributes network-wide configuration information.
+The Thread Leader is a Mesh Extender that is responsible for managing
+the set of Mesh Extenders in a Thread network. It is dynamically
+self-elected for fault tolerance, and aggregates and distributes
+network-wide configuration information.
 
 Note: There is always a single Leader in each Thread network
 [partition](#partitions).
@@ -132,22 +138,23 @@ There are limits to the number of device types a single Thread network supports.
 Role | Limit
 ----|----
 Leader | 1
-Router | 32
-End Device | 511 per Router
+Mesh Extender | 32
+End Device | 511 per Mesh Extender
 
-Thread tries to keep the number of Routers between 16 and 23. If a REED attaches
-as an End Device and the number of Routers in the network is below 16, it
-automatically promotes itself to a Router.
+Thread tries to keep the number of Mesh Extenders between 16 and
+23. If an ECD attaches as an End Device and the number of Mesh
+Extenders in the network is below 16, it automatically promotes itself
+to a Mesh Extender.
 
 ## Recap
 
 What you learned:
 
-*   A Thread device is either a Router (Parent) or an End Device (Child)
+*   A Thread device is either a Mesh Extender (Parent) or an End Device (Child)
 *   A Thread device is either a Full Thread Device (maintains IPv6 address
     mappings) or a Minimal Thread Device (forwards all messages to its Parent)
-*   A Router Eligible End Device can promote itself to a Router, and vice versa
-*   Every Thread network partition has a Leader to manage Routers
+*   A standby ECD can promote itself to a Mesh Extender, and vice versa
+*   Every Thread network partition has a Leader to manage Mesh Extenders
 *   A Border Router is used to connect Thread and non-Thread networks
 *   A Thread network might be composed of multiple partitions
 
@@ -162,7 +169,7 @@ What you learned:
       <div>Incorrect.</div>
     </div>
     <div correct>
-      <div>Router.</div>
+      <div>Mesh Extender.</div>
       <div>Correct.</div>
     </div>
     <div correct>
@@ -201,46 +208,46 @@ What you learned:
 
 <div>
   <devsite-multiple-choice>
-    <div>Which of the following statements about Routers is not true?</div>
+    <div>Which of the following statements about Mesh Extenders is not true?</div>
     <div correct>
-      <div>A Router can disable its transceiver to reduce power.</div>
-      <div>Devices that are functioning as Routers do not disable their
-        transceiver. (If they did, they'd be unable to function properly as a
-        Router.)</div>
+      <div>A Mesh Extender can disable its transceiver to reduce power.</div>
+      <div>Devices that are functioning as Mesh Extenders do not disable their
+        transceivers. (If they did, they'd be unable to function properly as a
+        Mesh Extender.)</div>
     </div>
     <div>
-      <div>A Router forwards packets for network devices.</div>
+      <div>A Mesh Extender forwards packets for network devices.</div>
       <div>This statement is true.</div>
     </div>
     <div>
-      <div>A Router keeps its transceiver enabled at all times.</div>
-      <div>This statement is true. In order to function properly as a Router,
+      <div>A Mesh Extender keeps its transceiver enabled at all times.</div>
+      <div>This statement is true. In order to function properly as a Mesh Extender,
       a device must keep its transceiver online at all times.</div>
     </div>
     <div>
-      <div>A Router provides secure commissioning services for devices trying 
+      <div>A Mesh Extender provides secure commissioning services for devices trying 
       to join the network.</div>
       <div>This statement is true. Commissioning is an important function of a
-      Thread Router.</div>
+      Mesh Extender.</div>
     </div>
   </devsite-multiple-choice>
 </div>
 
 <div>
   <devsite-multiple-choice>
-    <div>When can a device upgrade itself to a Router?</div>
+    <div>When can a device upgrade itself to a Mesh Extender?</div>
     <div correct>
-      <div>When it is a REED and it is the only node in reach of a new End
-        Device seeking to join the Thread network.</div>
-      <div>That's right. Under these circumstances, a REED can promote itself
-        to a Router.</div>
+      <div>When it is a standby Extender-Capable Device and it is the only node in reach of a new Thread
+        device seeking to join the Thread network.</div>
+      <div>That's right. Under these circumstances, a standby Extender-Capable Device can promote itself
+        to a Mesh Extender.</div>
     </div>
     <div>
       <div>When it is an End Device seeking to join the Thread network.</div>
       <div>Incorrect.</div>
     </div>
     <div>
-      <div>When it is a REED and the Thread network has merged with a larger
+      <div>When it is a standby Extender-Capable Device and the Thread network has merged with a larger
         network.</div>
       <div>Incorrect.</div>
     </div>
@@ -249,24 +256,24 @@ What you learned:
 
 <div>
   <devsite-multiple-choice>
-    <div>When can a Router cause itself to stop acting as a Router?</div>
+    <div>When can a Mesh Extender cause itself to stop acting as a Mesh Extender?</div>
     <div correct>
       <div>When it has no children.</div>
-      <div>That's correct. A Router with no children may revert to
-        an End Device on its own.</div>
+      <div>That's correct. A Mesh Extender with no children may revert to
+        a standby ECD on its own.</div>
     </div>
     <div>
       <div>When a new End Device is seeking to join the
         Thread network.</div>
-      <div>Wrong. A Router cannot revert to an End Device in this scenario.
+      <div>Wrong. A Mesh Extender cannot revert to a standby ECD in this scenario.
       </div>
     </div>
     <div correct>
-      <div>When another device on the network elects to become a Router.
+      <div>When another device on the network elects to become a Mesh Extender.
       </div>
-      <div>This could be true. If the number of Thread routers increases to 24
-      or more, existing Thread routers can start evaluating whether to become an
-      end device.
+      <div>This could be true. If the number of Mesh Extenders increases to 24
+      or more, existing Mesh Extenders can start evaluating whether to become a
+      standby ECD.
       </div>
     </div>
   </devsite-multiple-choice>
@@ -292,7 +299,7 @@ What you learned:
       <div>Incorrect.</div>
     </div>
     <div>
-      <div>All the Routers in the network have gone offline.</div>
+      <div>All the Mesh Extenders in the network have gone offline.</div>
       <div>Incorrect. In that case, none of the nodes would be able to
       communicate with one another.</div>
     </div>    

--- a/site/en/guides/thread-primer/router-selection.md
+++ b/site/en/guides/thread-primer/router-selection.md
@@ -1,4 +1,4 @@
-# Router Selection
+# Mesh Extender Selection
 
 ## Connected Dominating Set
 
@@ -6,53 +6,57 @@
 <a href="../images/ot-primer-cds.png"><img src="../images/ot-primer-cds.png" width="350" border="0" alt="OT Connected Dominating Set" /></a><figcaption style="text-align: center"><i>Example of a Connected Dominating Set</i></figcaption>
 </figure>
 
-Routers must form a Connected Dominating Set (CDS), which means:
+Mesh Extenders must form a Connected Dominating Set (CDS), which means:
 
-1.  There is a Router-only path between any two Routers.
-1.  Any one Router in a Thread network can reach any other Router by staying
-    entirely within the set of Routers.
-1.  Every End Device in a Thread network is directly connected to a Router.
+1.  There is a Mesh Extender-only path between any two Mesh Extenders.
+1.  Any one Mesh Extender in a Thread network can reach any other Mesh Extender by staying
+    entirely within the set of Mesh Extenders.
+1.  Every End Device in a Thread network is directly connected to a Mesh Extender.
 
 A distributed algorithm maintains the CDS, which ensures a minimum level of
 redundancy. Every device initially attaches to the network as an End Device
 (Child). As the state of the Thread network changes, the algorithm adds or
-removes Routers to maintain the CDS.
+removes Mesh Extenders to maintain the CDS.
 
-Thread adds Routers to:
+Thread adds Mesh Extenders to:
 
-*   Increase coverage if the network is below the Router threshold of 16
+*   Increase coverage if the network is below the Mesh Extender threshold of 16
 *   Increase path diversity
 *   Maintain a minimum level of redundancy
 *   Extend connectivity and support more Children
 
-Thread removes Routers to:
+Thread removes Mesh Extenders (switching them to standby
+Extender-Capable Devices (ECDs)) to:
 
-*   Reduce the Routing state below the maximum of 32 Routers
-*   Allow new Routers in other parts of the network when needed
+*   Keep the Routing state below the maximum of 32 Mesh Extenders
+*   Allow new Mesh Extenders in other parts of the network when needed
 
-## Upgrade to a Router
+## Upgrade to a Mesh Extender
 
-After attaching to a Thread network, the Child device may elect to become a
-Router. Before initiating the MLE Link Request process, the Child sends an
-Address Solicit message to the Leader, asking for a Router ID. If the Leader
-accepts, it responds with a Router ID and the Child upgrades itself to a Router.
+After attaching to a Thread network, a Child device that is an
+Extender-Capable Device may elect to become a Mesh Extender. Before
+initiating the MLE Link Request process, the Child sends an Address
+Solicit message to the Leader, asking for a Router ID. If the Leader
+accepts, it responds with a Router ID and the Child upgrades itself to
+a Mesh Extender.
 
 The MLE Link Request process is then used to establish bi-directional
-Router-Router links with neighboring Routers.
+Mesh Extender links with neighboring Mesh Extenders.
 
-1.  The new Router sends a multicast [Link Request](#1_link_request) to
-    neighboring Routers.
-1.  Routers respond with [Link Accept and Request](#2_link_accept_and_request)
+1.  The new Mesh Extender sends a multicast [Link Request](#1_link_request) to
+    neighboring Mesh Extenders.
+1.  Mesh Extenders respond with [Link Accept and Request](#2_link_accept_and_request)
     messages.
-1.  The new Router responds to each Router with a unicast [Link
-    Accept](#3_link_accept) to establish the Router-Router link.
+1.  The new Mesh Extender responds to each Mesh Extender with a unicast [Link
+    Accept](#3_link_accept) to establish the Mesh Extender link.
 
 ### 1. Link Request
 
-A Link Request is a request from the Router to all other Routers in the Thread
-network. When first becoming a Router, the device sends a multicast Link Request
-to `ff02::2`. Later, after discovering the other Routers via MLE Advertisements,
-the devices send unicast Link Requests.
+A Link Request is a request from the Mesh Extender to all other Mesh
+Extenders in the Thread network. When first becoming a Mesh Extender,
+the device sends a multicast Link Request to `ff02::2`. Later, after
+discovering the other Mesh Extenders via MLE Advertisements, the
+devices send unicast Link Requests.
 
 <figure>
 <a href="../images/ot-primer-network-mle-link-request-01.png"><img src="../images/ot-primer-network-mle-link-request-01.png" width="350" border="0" alt="OT MLE Link Request" /></a>
@@ -80,7 +84,7 @@ the devices send unicast Link Requests.
     <tr>
       <td width="25%"><b>Leader
         Data</b></td>
-      <td>Information about the Router's Leader, as stored on the sender (RLOC,
+      <td>Information about the Mesh Extender's Leader, as stored on the sender (RLOC,
         Partition ID, Partition weight)</td>
     </tr>
   </tbody>
@@ -98,9 +102,9 @@ reduce the number of messages from four to three.
 
 ### 3. Link Accept
 
-A Link Accept is a unicast response to a Link Request from a neighboring Router
-that provides information about itself and accepts the link to the neighboring
-Router.
+A Link Accept is a unicast response to a Link Request from a
+neighboring Mesh Extender that provides information about itself and
+accepts the link to the neighboring Mesh Extender.
 
 <figure>
 <a href="../images/ot-primer-network-mle-link-request-03.png"><img src="../images/ot-primer-network-mle-link-request-03.png" width="350" border="0" alt="OT MLE Link Accept" /></a>
@@ -138,42 +142,43 @@ Router.
     <tr>
       <td width="25%"><b>Leader
         Data</b></td>
-      <td>Information about the Router's Leader, as stored on the sender (RLOC,
+      <td>Information about the Mesh Extender's Leader, as stored on the sender (RLOC,
         Partition ID, Partition weight)</td>
     </tr>
   </tbody>
 </table>
 
-## Downgrade to a REED
+## Downgrade to a standby Extender-Capable Device
 
-When a Router downgrades to a REED, its Router-Router links are disconnected,
-and the device initiates the MLE Attach process to establish a Child-Parent
-link.
+When a Mesh Extender downgrades to a standby Extender-Capable Device,
+its Mesh Extender links are disconnected, and the device initiates the
+MLE Attach process to establish a Child-Parent link.
 
-See [Join an existing
-network](network-discovery.md)
-for more information on the MLE Attach process.
+See [Join an existing network](network-discovery.md) for more
+information on the MLE Attach process.
 
 ## One-way receive links
 
 In some scenarios, it may be necessary to establish a one-way receive link.
 
-After a Router reset, neighboring Routers may still have a valid receive link
-with the reset Router. In this case, the reset Router sends a Link Request
-message to re-establish the Router-Router link.
+After a Mesh Extender reset, neighboring Mesh Extenders may still have
+a valid receive link with the reset Mesh Extender. In this case, the
+reset Mesh Extender sends a Link Request message to re-establish the
+existing Mesh Extender link.
 
-An End Device may also wish to establish a receive link with neighboring
-non-Parent Routers to improve multicast reliability. We'll learn more about this
-when we get to Multicast Routing.
+An End Device may also wish to establish a receive link with
+neighboring non-Parent Mesh Extenders to improve multicast
+reliability. We'll learn more about this when we get to Multicast
+Routing.
 
 ## Recap
 
 What you've learned:
 
-*   Routers in a Thread network must form a Connected Dominating Set (CDS)
-*   Thread devices are upgraded to Routers or downgraded to End Devices to
-    maintain the CDS
-*   The MLE Link Request process is used to establish Router-Router links
+*   Mesh Extenders in a Thread network must form a Connected Dominating Set (CDS)
+*   Extender-Capable Devices (ECDs) can be upgraded to Mesh Extenders or
+    downgraded to standby ECDs to maintain the CDS
+*   The MLE Link Request process is used to establish Mesh Extender links
 
 ## Check your understanding
 
@@ -182,21 +187,21 @@ What you've learned:
     <div>Which of these rules are not enforced by a Connected Dominating Set
     (CDS)?</div>
     <div>
-      <div>There is a Router-only path between any two Routers.</div>
+      <div>There is a Mesh Extender-only path between any two Mesh Extenders.</div>
       <div>Incorrect.</div>
     </div>
     <div>
-      <div>Any one Router in a Thread network can reach any other Router by
-        staying entirely within the set of Routers.</div>
+      <div>Any one Mesh Extender in a Thread network can reach any other Mesh Extender by
+        staying entirely within the set of Mesh Extenders.</div>
       <div>Incorrect.</div>
     </div>
     <div>
       <div>Every End Device in a Thread network is directly connected to a
-        Router.</div>
+        Mesh Extender.</div>
       <div>Incorrect.</div>
     </div>
     <div correct>
-      <div>Only one Router in a Thread network may be a Border Router.</div>
+      <div>Only one Mesh Extender in a Thread network may be a Border Router.</div>
       <div>Correct. A Thread network may have multiple Border Routers.</div>
     </div>
   </devsite-multiple-choice>
@@ -204,22 +209,22 @@ What you've learned:
 
 <div>
   <devsite-multiple-choice>
-    <div>Why might a Router be removed from a Thread network?</div>
+    <div>Why might a Mesh Extender be removed (i.e. downgraded to a standby Extender-Capable Device) from a Thread network?</div>
     <div correct>
-      <div>To reduce the Routing state below the maximum of 32 Routers.</div>
+      <div>To keep the Routing state below the maximum of 32 Mesh Extenders.</div>
       <div>Correct. Thread networks strive to maintain an optimal number of
-        Routers. The most Routers that any Thread network should have is 32.
+        Mesh Extenders. The most Mesh Extenders that any Thread network should have is 32.
       </div>
     </div>
     <div>
       <div>To free up channels.</div>
-      <div>Incorrect. The number of routers has no relation to channel usage
+      <div>Incorrect. The number of Mesh Extenders has no relation to channel usage
       or capacity.</div>
     </div>
     <div correct>
-      <div>To allow the election of new Routers in other parts of the network
+      <div>To allow the election of new Mesh Extenders in other parts of the network
       when needed.</div>
-      <div>Correct. Reducing the number of active Routers in one part of a
+      <div>Correct. Reducing the number of Mesh Extenders in one part of a
       Thread network increases its ability to ramp up routing capacity
       elsewhere.</div>
     </div>
@@ -228,21 +233,21 @@ What you've learned:
 
 <div>
   <devsite-multiple-choice>
-    <div>What must happen before a REED that is attempting to become
-    a Router can establish direct links with the other Routers?</div>
+    <div>What must happen before an Extender-Capable Device that is attempting to become
+    a Mesh Extender can establish direct links with the other Mesh Extenders?</div>
     <div correct>
-      <div>The REED must send an Address Solicit message to the network Leader.
+      <div>The Extender-Capable Device must send an Address Solicit message to the network Leader.
       </div>
       <div>Correct.</div>
     </div>
     <div correct>
-      <div>The Leader must grant a Router ID to the REED.</div>
-      <div>Correct. Without a Router ID, the REED remains a Child device.</div>
+      <div>The Leader must grant a Router ID to the Extender-Capable Device.</div>
+      <div>Correct. Without a Router ID, the Extender-Capable Device remains an End Device (Child).</div>
     </div>
     <div>
-      <div>The REED must send an MLE Link Request.</div>
+      <div>The Extender-Capable Device must send an MLE Link Request.</div>
       <div>Wrong. The MLE Link Request is how the device establishes links to
-      other Routers once it has become a Router.</div>
+      other Mesh Extenders once it has become a Mesh Extender.</div>
     </div>
   </devsite-multiple-choice>
 </div>
@@ -250,16 +255,16 @@ What you've learned:
 <div>
   <devsite-multiple-choice>
     <div>Which of the following statements accurately describes what happens
-      when a Router downgrades?</div>
+      when a Mesh Extender downgrades?</div>
     <div>
-      <div>The device automatically remains on the network but as a Child (REED).
+      <div>The device automatically remains on the network but as a Child (standby Extender-Capable Device).
       </div>
-      <div>Wrong. There are more steps involved when a Router downgrades.</div>
+      <div>Wrong. There are more steps involved when a Mesh Extender downgrades.</div>
     </div>
     <div correct>
       <div>The device must initiate the MLE Attach process to establish a new
         connection to the network.</div>
-      <div>Correct. A device that downgrades from Router to REED is
+      <div>Correct. A device that downgrades from a Mesh Extender to a standby Extender-Capable Device is
         disconnected and must renegotiate its connection to the network.</div>
     </div>
   </devsite-multiple-choice>
@@ -267,7 +272,7 @@ What you've learned:
 
 <div>
   <devsite-multiple-choice>
-    <div>What process is used to establish Router-Router links?</div>
+    <div>What process is used to establish Mesh Extender links?</div>
     <div correct>
       <div>The MLE Link Request process.</div>
       <div>Correct.</div>
@@ -275,7 +280,7 @@ What you've learned:
     <div>
       <div>The Link Accept and Request process.</div>
       <div>Incorrect. There's no such thing as a Link Accept and Request process.
-        Link Accept and Request <em>messages</em> are sent by Routers in
+        Link Accept and Request <em>messages</em> are sent by Mesh Extenders in
         response to Link Request messages as part of the MLE Link Request
         process.</div>
     </div>


### PR DESCRIPTION
Update the Thread Primer documentation to transition terminology from Router and Router Eligible End Device (REED) to Mesh Extender and Extender-Capable Device (ECD), respectively.

- Rename "Router" to "Mesh Extender" (or "Active Mesh Extender" where referring specifically to the active parent role).
- Rename REED (Router Eligible End Device) to Extender-Capable Device (ECD).
- Rename "Router-Router links" to "Mesh Extender links".
- Adjust roles, device types, addressing, and MLE attach descriptions to use the new terminology.
- Fix grammatical errors and typos introduced during the transition.