### PR TITLE
Update command syntax for setting INFRA_IF_NAME

### DIFF
--- a/site/en/guides/border-router/build-docker.md
+++ b/site/en/guides/border-router/build-docker.md
@@ -43,7 +43,7 @@ specify it by setting the `INFRA_IF_NAME` environment variable before running th
 For example:
 
 ```
-$ INFRA_IF_NAME=eth0 curl -sSL https://raw.githubusercontent.com/openthread/ot-br-posix/refs/heads/main/etc/docker/border-router/setup-host | bash
+$ curl -sSL https://raw.githubusercontent.com/openthread/ot-br-posix/refs/heads/main/etc/docker/border-router/setup-host | INFRA_IF_NAME=eth0 bash
 ```
 
 ## Step 3: Get the OTBR Docker image


### PR DESCRIPTION
Include INFRA_IF_NAME with the bash command, it is now copy-past-able.