### PR TITLE
[codelabs] rename Router to Mesh Extender in simulation-posix codelab

### DIFF
--- a/site/en/codelabs/openthread-simulation-posix/index.lab.md
+++ b/site/en/codelabs/openthread-simulation-posix/index.lab.md
@@ -313,8 +313,8 @@ child
 Done
 ```
 
-Within 2 minutes you should see the state switch from `child` to `router`. A
-Mesh Extender is capable of routing traffic between Thread devices. It is also
+Within 2 minutes you should see the state switch from `child` to `router`.
+A Mesh Extender is capable of routing traffic between Thread devices. It is also
 referred to as a Parent.
 
 ```console

--- a/site/en/codelabs/openthread-simulation-posix/index.lab.md
+++ b/site/en/codelabs/openthread-simulation-posix/index.lab.md
@@ -137,8 +137,8 @@ OpenThread currently implements default values for network parameters (which can
 be changed later via the CLI).
 
 The figure below describes a basic Thread network topology. For this exercise,
-we'll simulate the two nodes within the green circle: a Thread Leader and Thread
-Router with a single connection between them.
+we'll simulate the two nodes within the green circle: a Thread Leader and a Mesh
+Extender with a single connection between them.
 
 <img src="img/6e3aa07675f902dc.png" alt="6e3aa07675f902dc.png" width="624.00" />
 
@@ -219,7 +219,7 @@ Done
 ```
 
 Wait a few seconds and verify that the device has become the Thread Leader.
-The Leader is the device responsible for managing router ID assignment.
+The Leader is the device responsible for managing Router ID assignment.
 
 ```console
 > state
@@ -314,7 +314,7 @@ Done
 ```
 
 Within 2 minutes you should see the state switch from `child` to `router`. A
-Thread Router is capable of routing traffic between Thread devices. It is also
+Mesh Extender is capable of routing traffic between Thread devices. It is also
 referred to as a Parent.
 
 ```console
@@ -432,8 +432,8 @@ Thread devices, and the authorizer for providing the network credentials
 required for the devices to join the network.
 
 In this exercise, we will use the same two-node topology as before. For
-authentication, the Thread Leader will act as the Commissioner, the Thread
-Router as a Joiner.
+authentication, the Thread Leader will act as the Commissioner, and the Mesh
+Extender as a Joiner.
 
 <img src="img/d6a67e8a0d0b5dcb.png" alt="d6a67e8a0d0b5dcb.png" width="624.00" />
 


### PR DESCRIPTION
Update the OpenThread POSIX Simulation codelab documentation to transition terminology from Thread Router to Mesh Extender.

- Rename Thread Router to Mesh Extender in network topology descriptions and commissioning joiner roles.
- Capitalize Router ID assignment description for consistency.