### PR TITLE
[codelabs] rename Router to Mesh Extender in silabs codelab

### DIFF
--- a/site/en/codelabs/silabs-openthread-hardware/index.lab.md
+++ b/site/en/codelabs/silabs-openthread-hardware/index.lab.md
@@ -356,7 +356,7 @@ With the out-of-band method, we know all security information and add the node m
 
 > aside positive
 >
-> **Note:** Because of the self configuring nature of a Thread network and these being Full Thread devices, either or both the FTDs may eventually become  routers. This can be found out using the `state` command.
+> **Note:** Because of the self configuring nature of a Thread network and these being Full Thread devices, either or both the FTDs may eventually become Mesh Extenders. This can be found out using the `state` command.
 
 ### Communication between Thread devices
 

--- a/site/en/codelabs/silabs-openthread-hardware/index.lab.md
+++ b/site/en/codelabs/silabs-openthread-hardware/index.lab.md
@@ -356,7 +356,7 @@ With the out-of-band method, we know all security information and add the node m
 
 > aside positive
 >
-> **Note:** Because of the self configuring nature of a Thread network and these being Full Thread devices, either or both the FTDs may eventually become Mesh Extenders. This can be found out using the `state` command.
+> **Note:** Because of the self configuring nature of a Thread network and these being Full Thread devices, either or both the FTDs may eventually become Mesh Extenders (which is indicated by the `state` command returning `router`).
 
 ### Communication between Thread devices
 

--- a/site/en/codelabs/silabs-openthread-hardware/index.lab.md
+++ b/site/en/codelabs/silabs-openthread-hardware/index.lab.md
@@ -356,7 +356,7 @@ With the out-of-band method, we know all security information and add the node m
 
 > aside positive
 >
-> **Note:** Because of the self configuring nature of a Thread network and these being Full Thread devices, either or both the FTDs may eventually become Mesh Extenders (which is indicated by the `state` command returning `router`).
+> **Note:** Because of the self-configuring nature of a Thread network and these being Full Thread devices, either or both of the FTDs may eventually become Mesh Extenders (which is indicated by the `state` command returning `router`).
 
 ### Communication between Thread devices
 


### PR DESCRIPTION
Update the Silicon Labs OpenThread Hardware codelab documentation to transition terminology from router to Mesh Extender.

- Rename FTD router role transition description to Mesh Extenders.