### PR TITLE
[codelabs] rename Router to Mesh Extender in esp codelab

### DIFF
--- a/site/en/codelabs/esp-openthread-hardware/index.lab.md
+++ b/site/en/codelabs/esp-openthread-hardware/index.lab.md
@@ -272,7 +272,7 @@ child
 Done
 ```
 
-Set the role to Router.
+Set the role to Mesh Extender.
 
 ```console
 > state router
@@ -397,7 +397,7 @@ I(37007) OPENTHREAD:[N] Mle-----------: Role detached -> child
 
 ```
 
-Set the role to Router.
+Set the role to Mesh Extender.
 
 ```console
 > state router

--- a/site/en/codelabs/esp-openthread-hardware/index.lab.md
+++ b/site/en/codelabs/esp-openthread-hardware/index.lab.md
@@ -272,7 +272,7 @@ child
 Done
 ```
 
-Set the role to Mesh Extender (referred to as "router" in the CLI and logs).
+Set the role to Mesh Extender (referred to as `router` in the CLI and logs).
 
 ```console
 > state router
@@ -397,7 +397,7 @@ I(37007) OPENTHREAD:[N] Mle-----------: Role detached -> child
 
 ```
 
-Set the role to Mesh Extender (referred to as "router" in the CLI and logs).
+Set the role to Mesh Extender (referred to as `router` in the CLI and logs).
 
 ```console
 > state router

--- a/site/en/codelabs/esp-openthread-hardware/index.lab.md
+++ b/site/en/codelabs/esp-openthread-hardware/index.lab.md
@@ -272,7 +272,7 @@ child
 Done
 ```
 
-Set the role to Mesh Extender.
+Set the role to Mesh Extender (referred to as "router" in the CLI and logs).
 
 ```console
 > state router
@@ -397,7 +397,7 @@ I(37007) OPENTHREAD:[N] Mle-----------: Role detached -> child
 
 ```
 
-Set the role to Mesh Extender.
+Set the role to Mesh Extender (referred to as "router" in the CLI and logs).
 
 ```console
 > state router


### PR DESCRIPTION
Update the ESP OpenThread Hardware codelab documentation to transition terminology from Router to Mesh Extender.

- Rename role setting descriptions from Router to Mesh Extender.