### PR TITLE
[guides] rename Router to Mesh Extender in validate port guide

### DIFF
--- a/site/en/guides/porting/validate-the-port.md
+++ b/site/en/guides/porting/validate-the-port.md
@@ -115,7 +115,7 @@ fe80:0:0:0:6447:6e10:cf7:ee29
 Done
 ```
 
-Send an ICMPv6 ping from Router to Leader's Mesh-Local EID IPv6 address:
+Send an ICMPv6 ping from Mesh Extender to Leader's Mesh-Local EID IPv6 address:
 
 ```
 > ping fdde:ad00:beef:0:5b:3bcd:deff:7786


### PR DESCRIPTION
Update the port validation guide to transition terminology from Router to Mesh Extender.

- Rename Router to Mesh Extender in ping step description.